### PR TITLE
Fix Sanity query syntax for Japanese field names

### DIFF
--- a/src/lib/fetchQuizzes.js
+++ b/src/lib/fetchQuizzes.js
@@ -8,7 +8,7 @@ export async function fetchAllQuizzes() {
       title,
       "slug": slug.current,
       category->{ _id, title },
-      "mainImage": 問題画像{ asset->{ url, metadata } },
+      "mainImage": "問題画像"{ asset->{ url, metadata } },
       problemDescription,
       _createdAt
     }
@@ -32,7 +32,7 @@ export async function fetchQuizBySlug(slug) {
       category->{ _id, title },
       problemDescription,
       hint,
-      "mainImage": 問題画像{ asset->{ url, metadata } },
+      "mainImage": "問題画像"{ asset->{ url, metadata } },
       answerImage{ asset->{ url, metadata } },
       answerExplanation,
       closingMessage,
@@ -56,7 +56,7 @@ export async function fetchQuizzesByCategory(category) {
       title,
       "slug": slug.current,
       category->{ _id, title },
-      "mainImage": 問題画像{ asset->{ url, metadata } },
+      "mainImage": "問題画像"{ asset->{ url, metadata } },
       problemDescription,
       _createdAt
     }

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -7,7 +7,7 @@ const QUIZZES_QUERY = /* groq */ `
   title,
   "slug": slug.current,
   category->{ _id, title },
-  "mainImage": 問題画像{
+  "mainImage": "問題画像"{
     asset->{
       _id,
       url,

--- a/src/routes/quiz/[slug]/+page.server.js
+++ b/src/routes/quiz/[slug]/+page.server.js
@@ -15,7 +15,7 @@ const QUERY = /* groq */ `
   category->{ _id, title },
   problemDescription,
   hint,
-  "mainImage": 問題画像{ asset->{ url, metadata } },
+  "mainImage": "問題画像"{ asset->{ url, metadata } },
   answerImage{ asset->{ url, metadata } },
   answerExplanation,
   closingMessage


### PR DESCRIPTION
- Add quotes around 問題画像 field name in GROQ queries
- Fix syntax error that prevented data retrieval
- Resolve 'まだクイズが投稿されていません' issue