### PR TITLE
Fix: show Sanity mainImage on home thumbnails

### DIFF
--- a/src/lib/fetchQuizzes.js
+++ b/src/lib/fetchQuizzes.js
@@ -8,7 +8,7 @@ export async function fetchAllQuizzes() {
       title,
       "slug": slug.current,
       category->{ _id, title },
-      "mainImage": "問題画像"{ asset->{ url, metadata } },
+      mainImage, asset->{ url, metadata } },
       problemDescription,
       _createdAt
     }
@@ -32,7 +32,7 @@ export async function fetchQuizBySlug(slug) {
       category->{ _id, title },
       problemDescription,
       hint,
-      "mainImage": "問題画像"{ asset->{ url, metadata } },
+      mainImage, asset->{ url, metadata } },
       answerImage{ asset->{ url, metadata } },
       answerExplanation,
       closingMessage,
@@ -56,7 +56,7 @@ export async function fetchQuizzesByCategory(category) {
       title,
       "slug": slug.current,
       category->{ _id, title },
-      "mainImage": "問題画像"{ asset->{ url, metadata } },
+      mainImage, asset->{ url, metadata } },
       problemDescription,
       _createdAt
     }

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -7,13 +7,8 @@ const QUIZZES_QUERY = /* groq */ `
   title,
   "slug": slug.current,
   category->{ _id, title },
-  "mainImage": "問題画像"{
-    asset->{
-      _id,
-      url,
-      metadata
-    }
-  },
+  mainImage,
+  problemDescription
   problemDescription
 }`;
 


### PR DESCRIPTION
ホームの新着一覧で、サムネイルは Sanity の `mainImage` を使用するよう修正。
- `"問題画像"` ラベル参照を `mainImage` に置換
- 画像はオブジェクトのまま返し、ブラウザ側の image-url builder で変換
