### PR TITLE
Home: fix thumbnail images from Sanity

### DIFF
--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -8,6 +8,8 @@ const QUIZZES_QUERY = /* groq */ `
   "slug": slug.current,
   category->{ _id, title },
   mainImage,
+  // SSR用のサムネイルURL（asset参照がない場合の保険）
+  "thumbnailUrl": mainImage.asset->url,
   problemDescription
 }`;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -3,22 +3,18 @@
   import { urlFor } from '$lib/sanityPublic.js';
   
   function getImageUrl(quiz) {
-    console.log('Quiz data:', quiz);
-    console.log('MainImage:', quiz.mainImage);
-    
-    if (!quiz.mainImage || !quiz.mainImage.asset) {
-      console.log('No mainImage or asset found');
-      return 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDYwMCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSI2MDAiIGhlaWdodD0iMzYwIiBmaWxsPSIjRjNGNEY2Ii8+Cjx0ZXh0IHg9IjMwMCIgeT0iMTgwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjOUI5QkEwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxOCI+44Kk44Oh44O844K4</text>Cjwvc3ZnPgo=';
+    // 1) 参照があれば builder で最適化URL
+    if (quiz?.mainImage && quiz.mainImage.asset && !quiz.mainImage.asset.url) {
+      try {
+        return urlFor(quiz.mainImage).width(600).height(360).fit('crop').url();
+      } catch {}
     }
-    
-    try {
-      const imageUrl = urlFor(quiz.mainImage).width(600).height(360).fit('crop').url();
-      console.log('Generated image URL:', imageUrl);
-      return imageUrl;
-    } catch (error) {
-      console.error('Error generating image URL:', error);
-      return 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDYwMCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSI2MDAiIGhlaWdodD0iMzYwIiBmaWxsPSIjRjNGNEY2Ii8+Cjx0ZXh0IHg9IjMwMCIgeT0iMTgwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjOUI5QkEwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxOCI+44Kk44Oh44O844K4</text>Cjwvc3ZnPgo=';
-    }
+    // 2) SSRで付与したサムネイルURLをフォールバック
+    if (quiz?.thumbnailUrl) return quiz.thumbnailUrl;
+    // 3) さらにフォールバック: そのままURLがあれば利用
+    if (quiz?.mainImage?.asset?.url) return quiz.mainImage.asset.url;
+    // 4) 何も無ければプレースホルダ
+    return 'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNjAwIiBoZWlnaHQ9IjM2MCIgdmlld0JveD0iMCAwIDYwMCAzNjAiIGZpbGw9Im5vbmUiIHhtbG5zPSJodHRwOi8vd3d3LnczLm9yZy8yMDAwL3N2ZyI+CjxyZWN0IHdpZHRoPSI2MDAiIGhlaWdodD0iMzYwIiBmaWxsPSIjRjNGNEY2Ii8+Cjx0ZXh0IHg9IjMwMCIgeT0iMTgwIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjOUI5QkEwIiBmb250LWZhbWlseT0ic2Fucy1zZXJpZiIgZm9udC1zaXplPSIxOCI+44Kk44Oh44O844K4</text>Cjwvc3ZnPgo=';
   }
 </script>
 


### PR DESCRIPTION
トップの新着サムネイルが空になるケースに対処：
- サーバで `thumbnailUrl = mainImage.asset->url` を付与
- クライアントで `urlFor` を最優先しつつフォールバックを追加
- これにより Studio の問題画像が確実に表示されます
