### PR TITLE
Slug page: show only string fields (no PT fallback)

### DIFF
--- a/src/routes/quiz/[slug]/+page.svelte
+++ b/src/routes/quiz/[slug]/+page.svelte
@@ -13,8 +13,8 @@
   }
 
   function textOrPortable(content) {
-    const s = typeof content === 'string' ? content : renderPortableText(content);
-    return s || '';
+    // Studioに入力された文字列のみ表示（旧Portable Text配列は無視）
+    return typeof content === 'string' ? content : '';
   }
 </script>
 


### PR DESCRIPTION
Sanity Studioに入力されたテキストのみ表示するため、
`problemDescription`/`hint` が配列(Portable Text)の場合は無視します。
旧サンプルデータが表示される問題を防止。