### PR TITLE
Sanity: data source indicator + no-store + health env public

### DIFF
--- a/src/routes/health/env_public/+server.js
+++ b/src/routes/health/env_public/+server.js
@@ -1,0 +1,11 @@
+import { json } from '@sveltejs/kit';
+import { env as pub } from '$env/dynamic/public';
+
+export function GET() {
+  return json({
+    VITE_SANITY_PROJECT_ID: pub.VITE_SANITY_PROJECT_ID ?? null,
+    VITE_SANITY_DATASET: pub.VITE_SANITY_DATASET ?? null,
+    VITE_SANITY_API_VERSION: pub.VITE_SANITY_API_VERSION ?? null
+  });
+}
+

--- a/src/routes/quiz/[slug]/+page.svelte
+++ b/src/routes/quiz/[slug]/+page.svelte
@@ -63,4 +63,7 @@
 
   <!-- 補助情報 -->
   <p style="color:#6b7280;font-size:.9rem;">slug: <code>{quiz.slug}</code></p>
+  {#if data.__dataSource}
+    <p style="color:#9ca3af;font-size:.75rem;">__dataSource: {data.__dataSource}</p>
+  {/if}
 </main>


### PR DESCRIPTION
目的: 本番が Sanity を参照しているか可視化＆整備

- /quiz/[slug] の `+page.server.js`
  - `__dataSource` を返却（sanity/stub）
  - `Cache-Control: no-store` を付与（更新即反映）
  - `prerender = false` を明示
- /quiz/[slug] の `+page.svelte` に `__dataSource` を一時表示
- /health/env_public を追加（VITE_SANITY_* を確認）

DoD:
- __dataSource が "sanity" で表示
- Studio更新 → 本番反映（no-store）
- スタブ文言無し（未取得時は空表示）
