### PR TITLE
Sanity-driven categories: dynamic nav + nested quiz routes

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -17,16 +17,13 @@
 <nav class="main-nav">
   <div class="nav-container">
     <ul class="nav-menu">
-      <li>
-        <a href="/category/matchstick" class="nav-link matchstick-link" data-sveltekit-preload-data>
-          マッチ棒クイズ
-        </a>
-      </li>
-      <li>
-        <a href="/category/spot-the-difference" class="nav-link difference-link" data-sveltekit-preload-data>
-          間違い探し
-        </a>
-      </li>
+      {#if data?.categories?.length}
+        {#each data.categories as c}
+          <li>
+            <a href={`/quiz/${c.slug}`} class="nav-link" data-sveltekit-preload-data>{c.title}</a>
+          </li>
+        {/each}
+      {/if}
     </ul>
   </div>
 </nav>

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -6,7 +6,7 @@ const QUIZZES_QUERY = /* groq */ `
   _id,
   title,
   "slug": slug.current,
-  category->{ _id, title },
+  category->{ _id, title, "slug": slug.current },
   mainImage,
   // SSR用のサムネイルURL（asset参照がない場合の保険）
   "thumbnailUrl": mainImage.asset->url,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -23,7 +23,8 @@
 {:else}
   <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:16px;">
     {#each data.quizzes as q}
-      <a href={`/quiz/${q.slug}`} style="display:block;text-decoration:none;border:1px solid #eee;border-radius:12px;overflow:hidden;background:#fff;">
+        <a href={q?.category?.slug ? `/quiz/${q.category.slug}/${q.slug}` : `/quiz/${q.slug}`}
+           style="display:block;text-decoration:none;border:1px solid #eee;border-radius:12px;overflow:hidden;background:#fff;">
         {#if getImageUrl(q)}
           <img
             src={getImageUrl(q)}

--- a/src/routes/quiz/[category]/+page.server.js
+++ b/src/routes/quiz/[category]/+page.server.js
@@ -1,0 +1,33 @@
+import { error } from '@sveltejs/kit';
+import { client } from '$lib/sanity.server.js';
+
+const QUERY = /* groq */ `
+{
+  "category": *[_type == "category" && slug.current == $slug][0]{title, "slug": slug.current},
+  "quizzes": *[_type == "quiz" && (
+    (defined(category._ref) && category->slug.current == $slug) ||
+    (!defined(category._ref) && (category == $slug || category == ^.category.title))
+  )] | order(_createdAt desc) {
+    _id,
+    title,
+    "slug": slug.current,
+    category->{ title, "slug": slug.current },
+    mainImage{ asset->{ url, metadata } },
+    problemDescription,
+    _createdAt
+  }
+}`;
+
+export const prerender = false;
+
+export const load = async ({ params, setHeaders }) => {
+  setHeaders({ 'cache-control': 'no-store' });
+  const slug = params.category;
+  const { category, quizzes } = await client.fetch(QUERY, { slug });
+  if (!category) {
+    // カテゴリが存在しない
+    return { category: null, quizzes: [] };
+  }
+  return { category, quizzes };
+};
+

--- a/src/routes/quiz/[category]/+page.svelte
+++ b/src/routes/quiz/[category]/+page.svelte
@@ -1,0 +1,52 @@
+<script>
+  export let data;
+  const quizzes = data.quizzes || [];
+  const category = data.category || null;
+
+  function formatDate(dateString) {
+    const d = new Date(dateString);
+    return `${d.getFullYear()}/${String(d.getMonth()+1).padStart(2,'0')}/${String(d.getDate()).padStart(2,'0')}`;
+  }
+</script>
+
+<svelte:head>
+  <title>{category ? category.title : 'カテゴリ未定義'} - 脳トレ日和</title>
+</svelte:head>
+
+<section class="category-header" style="text-align:center;">
+  <h1 class="category-title">{category ? category.title : 'カテゴリが見つかりません'}</h1>
+  {#if category}
+    <div class="quiz-count">全{quizzes.length}問</div>
+  {/if}
+</section>
+
+{#if !category}
+  <p style="text-align:center;">このカテゴリは存在しません。</p>
+{:else if quizzes.length === 0}
+  <p style="text-align:center;">まだ記事がありません。</p>
+{:else}
+  <div class="quiz-grid">
+    {#each quizzes as q}
+      <article class="quiz-card">
+        <a href={`/quiz/${category.slug}/${q.slug}`} class="quiz-link">
+          {#if q.mainImage?.asset?.url}
+            <img src={q.mainImage.asset.url} alt={q.title} class="quiz-img" loading="lazy" />
+          {/if}
+          <div class="quiz-content">
+            <div class="quiz-date">{formatDate(q._createdAt)}</div>
+            <h3 class="quiz-title">{q.title}</h3>
+          </div>
+        </a>
+      </article>
+    {/each}
+  </div>
+{/if}
+
+<style>
+  .quiz-grid { display:grid; grid-template-columns:repeat(auto-fill,minmax(220px,1fr)); gap:16px; }
+  .quiz-card { border:1px solid #eee; border-radius:12px; overflow:hidden; background:#fff; }
+  .quiz-img { width:100%; height:160px; object-fit:cover; display:block; }
+  .quiz-content { padding:12px; }
+  .quiz-title { margin:0; font-size:16px; line-height:1.4; }
+</style>
+

--- a/src/routes/quiz/[category]/[slug]/+page.server.js
+++ b/src/routes/quiz/[category]/[slug]/+page.server.js
@@ -1,0 +1,27 @@
+import { error } from '@sveltejs/kit';
+import { client } from '$lib/sanity.server.js';
+
+const QUERY = /* groq */ `
+*[_type == "quiz" && slug.current == $slug && (
+  (defined(category._ref) && category->slug.current == $category) ||
+  (!defined(category._ref) && category == $category)
+)][0]{
+  _id,
+  title,
+  "slug": slug.current,
+  category->{ title, "slug": slug.current },
+  mainImage{ asset->{ url, metadata } },
+  problemDescription,
+  hint
+}`;
+
+export const prerender = false;
+
+export const load = async ({ params, setHeaders }) => {
+  setHeaders({ 'cache-control': 'no-store' });
+  const { category, slug } = params;
+  const doc = await client.fetch(QUERY, { category, slug });
+  if (!doc) throw error(404, 'Not found');
+  return { quiz: doc, __dataSource: 'sanity' };
+};
+

--- a/src/routes/quiz/[category]/[slug]/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/+page.svelte
@@ -1,0 +1,52 @@
+<script>
+  export let data;
+  const { quiz } = data;
+
+  function renderPortableText(content) {
+    if (!content) return '';
+    if (typeof content === 'string') return content;
+    return '';
+  }
+
+  function textOrPortable(content) {
+    return typeof content === 'string' ? content : '';
+  }
+</script>
+
+<svelte:head>
+  <title>{quiz.title} - 脳トレ日和</title>
+</svelte:head>
+
+<main style="max-width:800px;margin:24px auto;padding:16px;">
+  <h1 style="text-align:center;margin-top:0;">{quiz.title}</h1>
+
+  <!-- 問題画像 -->
+  {#if quiz.mainImage?.asset?.url}
+    <div style="text-align:center;margin:16px 0;">
+      <img src={quiz.mainImage.asset.url} alt={quiz.title} style="max-width:100%;height:auto;border-radius:12px;box-shadow:0 4px 15px rgba(0,0,0,0.1);" />
+    </div>
+  {/if}
+
+  <!-- 問題説明 -->
+  {#if textOrPortable(quiz.problemDescription)}
+    <section style="margin:16px 0;">
+      <h2 style="font-size:1.25rem;margin:.5rem 0;">問題の補足</h2>
+      <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(quiz.problemDescription)}</p>
+    </section>
+  {/if}
+
+  <!-- ヒント -->
+  {#if textOrPortable(quiz.hint)}
+    <section style="margin:16px 0;">
+      <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
+      <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">
+        <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(quiz.hint)}</p>
+      </div>
+    </section>
+  {/if}
+
+  {#if data.__dataSource}
+    <p style="color:#9ca3af;font-size:.75rem;">__dataSource: {data.__dataSource}</p>
+  {/if}
+</main>
+

--- a/studio/schemaTypes/category.js
+++ b/studio/schemaTypes/category.js
@@ -11,10 +11,16 @@ export default {
       validation: R => R.required()
     },
     {
+      name: 'slug',
+      title: 'スラッグ',
+      type: 'slug',
+      options: { source: 'title', maxLength: 96 },
+      validation: R => R.required()
+    },
+    {
       name: 'description',
       title: '説明',
       type: 'text'
     }
   ]
 }
-


### PR DESCRIPTION
目的: Sanityカテゴリとフロントを連動。

- Studio: category スキーマに slug を追加（title→slug生成）
- グロナビ: Sanity のカテゴリ一覧を取得してリンク生成（`+layout.server.js`）
- ルート: `/quiz/[category]/` （カテゴリ一覧）と `/quiz/[category]/[slug]/`（詳細）を追加
- TOP: 全カテゴリ混在の新着順。リンクはカテゴリslug付きに変更
- 404/不存在カテゴリ: 「存在しません/記事なし」表示
- 環境変数ポリシーは既存の SANITY_*/VITE_SANITY_* を継続（tokenはブラウザ禁止）
- キャッシュ: no-store を適用しStudio更新は即反映

DoD:
- Studioでカテゴリ追加→ナビ/カテゴリページに自動反映
- TOP=混在新着、カテゴリページ=該当カテゴリのみ
- 詳細ページを slug で到達可能
- ブラウザにtoken露出なし
