### PR TITLE
Fix: dynamic nav wiring and no-store on top

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -1,4 +1,5 @@
 <script>
+  export let data;
   import "../lib/styles/global.css";
 </script>
 

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -13,7 +13,8 @@ const QUIZZES_QUERY = /* groq */ `
   problemDescription
 }`;
 
-export const load = async () => {
+export const load = async ({ setHeaders }) => {
+  setHeaders({ 'cache-control': 'no-store' });
   try {
     console.log('[+page.server.js] Fetching quizzes from Sanity...');
     const quizzes = await client.fetch(QUIZZES_QUERY);


### PR DESCRIPTION
グロナビの動的カテゴリを有効化するため `+layout.svelte` に `export let data` を追加。
TOPの新着取得は `no-store` を付与してStudio更新が即時反映されるようにしました。