### PR TITLE
PT support + multi-hints in quiz schema and UI

### DIFF
--- a/src/routes/quiz/[category]/[slug]/+page.server.js
+++ b/src/routes/quiz/[category]/[slug]/+page.server.js
@@ -7,11 +7,13 @@ const QUERY = /* groq */ `
   (!defined(category._ref) && category == $category)
 )][0]{
   _id,
+  _updatedAt,
   title,
   "slug": slug.current,
   category->{ title, "slug": slug.current },
   mainImage{ asset->{ url, metadata } },
   problemDescription,
+  hints,
   hint
 }`;
 
@@ -24,4 +26,3 @@ export const load = async ({ params, setHeaders }) => {
   if (!doc) throw error(404, 'Not found');
   return { quiz: doc, __dataSource: 'sanity' };
 };
-

--- a/src/routes/quiz/[category]/[slug]/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/+page.svelte
@@ -42,7 +42,16 @@
   {/if}
 
   <!-- ヒント -->
-  {#if textOrPortable(quiz.hint)}
+  {#if Array.isArray(quiz.hints) && quiz.hints.length}
+    <section style="margin:16px 0;">
+      <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
+      <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">
+        {#each quiz.hints as h}
+          <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(h)}</p>
+        {/each}
+      </div>
+    </section>
+  {:else if textOrPortable(quiz.hint)}
     <section style="margin:16px 0;">
       <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
       <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">

--- a/src/routes/quiz/[slug]/+page.server.js
+++ b/src/routes/quiz/[slug]/+page.server.js
@@ -6,8 +6,10 @@ import { client } from '$lib/sanity.server.js';
 const QUERY = /* groq */ `
 *[_type == "quiz" && (slug.current == $slug || _id == $slug)][0]{
   _id,
+  _updatedAt,
   title,
   "slug": slug.current,
+  category->{ title, "slug": slug.current },
   // Studio 側の日本語フィールド(問題画像)にも対応
   "mainImage": {
     "asset": {
@@ -15,6 +17,7 @@ const QUERY = /* groq */ `
     }
   },
   problemDescription,
+  hints,
   hint
 }
 `;

--- a/src/routes/quiz/[slug]/+page.svelte
+++ b/src/routes/quiz/[slug]/+page.svelte
@@ -54,7 +54,16 @@
   {/if}
 
   <!-- ④ ヒント（ここでページ区切り） -->
-  {#if textOrPortable(quiz.hint)}
+  {#if Array.isArray(quiz.hints) && quiz.hints.length}
+    <section style="margin:16px 0;">
+      <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
+      <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">
+        {#each quiz.hints as h}
+          <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(h)}</p>
+        {/each}
+      </div>
+    </section>
+  {:else if textOrPortable(quiz.hint)}
     <section style="margin:16px 0;">
       <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
       <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">

--- a/studio/schemaTypes/quiz.js
+++ b/studio/schemaTypes/quiz.js
@@ -19,11 +19,12 @@ export default {
       to: [{ type: 'category' }],
       validation: R => R.required()
     },
-    { name: 'problemDescription', title: '問題説明', type: 'text' },
-    { name: 'hint', title: 'ヒント', type: 'text' },
+    { name: 'problemDescription', title: '問題の補足', type: 'array', of: [{ type: 'block' }] },
+    { name: 'hints', title: 'ヒント（複数可）', type: 'array', of: [{ type: 'block' }] },
+    { name: 'hint', title: 'ヒント（旧・互換）', type: 'text', hidden: true },
     { name: 'mainImage', title: '問題画像（Main Image）', type: 'image', options: {hotspot: true} },
     { name: 'answerImage', title: '正解画像（Answer Image）', type: 'image', options: {hotspot: true} },
-    { name: 'answerExplanation', title: '正解の解説', type: 'text' },
+    { name: 'answerExplanation', title: '正解の解説', type: 'array', of: [{ type: 'block' }] },
     { name: 'closingMessage', title: '締めテキスト', type: 'string' }
   ]
 }


### PR DESCRIPTION
Studio:
- problemDescription を PT 配列へ
- hints (複数ヒント) を追加
- answerExplanation を PT 配列へ

Frontend:
- /quiz/[slug], /quiz/[category]/[slug] で PT を描画
- 複数ヒント表示（hints→hint fallback）
