### PR TITLE
Add nested answer page (/quiz/[category]/[slug]/answer)

### DIFF
--- a/src/routes/quiz/[category]/[slug]/answer/+page.server.js
+++ b/src/routes/quiz/[category]/[slug]/answer/+page.server.js
@@ -1,0 +1,25 @@
+import { error } from '@sveltejs/kit';
+import { client } from '$lib/sanity.server.js';
+
+const QUERY = /* groq */ `
+*[_type=='quiz' && slug.current==$slug && (
+  (defined(category._ref) && category->slug.current==$category) ||
+  (!defined(category._ref) && category==$category)
+)][0]{
+  title,
+  "slug": slug.current,
+  category->{ title, "slug": slug.current },
+  answerImage{ asset->{ url, metadata } },
+  answerExplanation
+}`;
+
+export const prerender = false;
+
+export const load = async ({ params, setHeaders }) => {
+  setHeaders({ 'cache-control': 'no-store' });
+  const { category, slug } = params;
+  const doc = await client.fetch(QUERY, { category, slug });
+  if (!doc) throw error(404, 'Not found');
+  return { quiz: doc, __dataSource: 'sanity' };
+};
+

--- a/src/routes/quiz/[category]/[slug]/answer/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/answer/+page.svelte
@@ -1,0 +1,46 @@
+<script>
+  export let data;
+  const { quiz } = data;
+
+  function renderPT(content){
+    if (!content) return '';
+    if (typeof content === 'string') return content;
+    if (Array.isArray(content)){
+      return content
+        .filter(b=>b?._type==='block')
+        .map(b=> b.children?.filter(c=>c?._type==='span')?.map(c=>c.text).join('') || '')
+        .join('\n');
+    }
+    return '';
+  }
+</script>
+
+<svelte:head>
+  <title>{quiz.title} 正解 - 脳トレ日和</title>
+</svelte:head>
+
+<main style="max-width:800px;margin:24px auto;padding:16px;">
+  <h1 style="text-align:center;margin-top:0;">{quiz.title}｜正解</h1>
+
+  {#if quiz.answerImage?.asset?.url}
+    <div style="text-align:center;margin:16px 0;">
+      <img src={quiz.answerImage.asset.url} alt="正解画像" style="max-width:100%;height:auto;border-radius:12px;box-shadow:0 4px 15px rgba(0,0,0,0.1);" />
+    </div>
+  {/if}
+
+  {#if renderPT(quiz.answerExplanation)}
+    <section style="margin:16px 0;">
+      <h2 style="font-size:1.25rem;margin:.5rem 0;">解説</h2>
+      <p style="white-space:pre-line;line-height:1.8;">{renderPT(quiz.answerExplanation)}</p>
+    </section>
+  {/if}
+
+  {#if data.__dataSource}
+    <p style="color:#9ca3af;font-size:.75rem;">__dataSource: {data.__dataSource}</p>
+  {/if}
+
+  <div style="text-align:center;margin:24px 0;">
+    <a href={`/quiz/${quiz.category?.slug}/${quiz.slug}`} style="text-decoration:none;">← 問題に戻る</a>
+  </div>
+</main>
+


### PR DESCRIPTION
カテゴリ付きの正解ページを追加し、PT配列の解説を表示します。