### PR TITLE
Fix: ensure problem/hints render via SSR fallback on slug route

### DIFF
--- a/src/routes/quiz/[slug]/+page.server.js
+++ b/src/routes/quiz/[slug]/+page.server.js
@@ -36,5 +36,22 @@ export const load = async (event) => {
   }
   // 失敗時は空表示（スタブにしない）
   const __dataSource = doc ? 'sanity' : 'stub';
-  return { quiz: doc, __dataSource };
+  // SSR用のプレーンテキスト化（PT配列→文字列）
+  const ptToText = (v) => {
+    if (!v) return '';
+    if (typeof v === 'string') return v;
+    if (Array.isArray(v)) {
+      return v
+        .filter((b) => b && b._type === 'block')
+        .map((b) => (b.children || [])
+          .filter((c) => c && c._type === 'span')
+          .map((c) => c.text)
+          .join(''))
+        .join('\n');
+    }
+    return '';
+  };
+  const problemText = doc ? ptToText(doc.problemDescription) : '';
+  const hintsText = doc && Array.isArray(doc.hints) ? doc.hints.map(ptToText).filter(Boolean) : [];
+  return { quiz: doc, __dataSource, problemText, hintsText };
 };

--- a/src/routes/quiz/[slug]/+page.svelte
+++ b/src/routes/quiz/[slug]/+page.svelte
@@ -46,21 +46,27 @@
   {/if}
 
   <!-- 問題説明 -->
-  {#if textOrPortable(quiz.problemDescription)}
+  {#if (data.problemText && data.problemText.length) || textOrPortable(quiz.problemDescription)}
     <section style="margin:16px 0;">
       <h2 style="font-size:1.25rem;margin:.5rem 0;">問題の補足</h2>
-      <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(quiz.problemDescription)}</p>
+      <p style="white-space:pre-line;line-height:1.8;">{data.problemText || textOrPortable(quiz.problemDescription)}</p>
     </section>
   {/if}
 
   <!-- ④ ヒント（ここでページ区切り） -->
-  {#if Array.isArray(quiz.hints) && quiz.hints.length}
+  {#if (Array.isArray(data.hintsText) && data.hintsText.length) || (Array.isArray(quiz.hints) && quiz.hints.length)}
     <section style="margin:16px 0;">
       <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
       <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">
-        {#each quiz.hints as h}
-          <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(h)}</p>
-        {/each}
+        {#if Array.isArray(data.hintsText) && data.hintsText.length}
+          {#each data.hintsText as h}
+            <p style="white-space:pre-line;line-height:1.8;">{h}</p>
+          {/each}
+        {:else}
+          {#each quiz.hints as h}
+            <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(h)}</p>
+          {/each}
+        {/if}
       </div>
     </section>
   {:else if textOrPortable(quiz.hint)}


### PR DESCRIPTION
サーバ側で PT をプレーン文字列に変換して `problemText`/`hintsText` を返却し、
/quiz/[slug] で確実に表示（no-store維持）。