### PR TITLE
Add Deploy Sanity Studio workflow

### DIFF
--- a/.github/workflows/deploy-studio.yml
+++ b/.github/workflows/deploy-studio.yml
@@ -1,0 +1,40 @@
+name: Deploy Sanity Studio
+
+on:
+  workflow_dispatch:
+    inputs:
+      host:
+        description: Studio hostname (without .sanity.studio)
+        required: false
+        default: noutore-biyori-studio-main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install deps (studio)
+        working-directory: studio
+        run: |
+          npm i -g pnpm
+          pnpm install --no-frozen-lockfile
+
+      - name: Sanity login (token)
+        run: npx -y sanity@latest login --with-token
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+
+      - name: Deploy Studio
+        working-directory: studio
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+        run: |
+          npx -y sanity@latest deploy "${{ github.event.inputs.host }}" --project quljge22 --dataset production --no-open
+

--- a/studio/sanity.cli.js
+++ b/studio/sanity.cli.js
@@ -1,0 +1,9 @@
+import {defineCliConfig} from 'sanity/cli'
+
+// Hardcode values for non-interactive deploys
+export default defineCliConfig({
+  api: {
+    projectId: 'quljge22',
+    dataset: 'production'
+  }
+})


### PR DESCRIPTION
Studio を non-interactive にデプロイできる GitHub Actions を追加しました。
Secrets: `SANITY_AUTH_TOKEN` が必要です。
Workflow: Actions → Deploy Sanity Studio → Run workflow から実行可能です。