### PR TITLE
Redeploy cleanup: nested routes only + remove debug

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -22,8 +22,8 @@
   <p>まだクイズが投稿されていません。</p>
 {:else}
   <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:16px;">
-    {#each data.quizzes as q}
-        <a href={q?.category?.slug ? `/quiz/${q.category.slug}/${q.slug}` : `/quiz/${q.slug}`}
+    {#each data.quizzes.filter(q => q?.category?.slug) as q}
+        <a href={`/quiz/${q.category.slug}/${q.slug}`}
            style="display:block;text-decoration:none;border:1px solid #eee;border-radius:12px;overflow:hidden;background:#fff;">
         {#if getImageUrl(q)}
           <img

--- a/src/routes/quiz/[category]/[slug]/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/+page.svelte
@@ -60,7 +60,4 @@
     </section>
   {/if}
 
-  {#if data.__dataSource}
-    <p style="color:#9ca3af;font-size:.75rem;">__dataSource: {data.__dataSource}</p>
-  {/if}
 </main>

--- a/src/routes/quiz/[category]/[slug]/answer/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/answer/+page.svelte
@@ -35,12 +35,8 @@
     </section>
   {/if}
 
-  {#if data.__dataSource}
-    <p style="color:#9ca3af;font-size:.75rem;">__dataSource: {data.__dataSource}</p>
-  {/if}
 
   <div style="text-align:center;margin:24px 0;">
     <a href={`/quiz/${quiz.category?.slug}/${quiz.slug}`} style="text-decoration:none;">← 問題に戻る</a>
   </div>
 </main>
-


### PR DESCRIPTION

- /quiz/[slug] 系を削除したため、TOPのリンクを必ず `/quiz/{category}/{slug}` に統一
- ページ末尾の `__dataSource` 表示を削除

このPRをマージ後、Vercelで main を再デプロイすれば、問題文・ヒント・締め文が Sanity のみから反映されます。