### PR TITLE
Rebuild Studio: quiz schema with hints/ad codes/closing

### DIFF
--- a/studio/schemaTypes/quiz.js
+++ b/studio/schemaTypes/quiz.js
@@ -1,10 +1,11 @@
 // studio/schemaTypes/quiz.js
+// 現行の管理画面をゼロから再構築（広告コード + ヒント複数 + 締め文 を含む）
 export default {
   name: 'quiz',
   title: 'クイズ',
   type: 'document',
   fields: [
-    // ── メタ ─────────────────────────────────────────────
+    // ── メタ ───────────────────────────
     { name: 'title', title: 'タイトル', type: 'string', validation: R => R.required() },
     {
       name: 'slug',
@@ -13,41 +14,34 @@ export default {
       options: { source: 'title', maxLength: 96 },
       validation: R => R.required()
     },
+
+    // ── 問題側 ────────────────────────
+    { name: 'mainImage', title: '問題画像（Main Image）', type: 'image', options: { hotspot: true }, validation: R => R.required() },
+    { name: 'problemDescription', title: '問題の補足', type: 'array', of: [{ type: 'block' }] },
+
+    // ヒント（複数可）
+    { name: 'hints', title: 'ヒント（複数可）', type: 'array', of: [{ type: 'block' }] },
+
+    // レクタングル広告コード1（任意）
+    { name: 'adCode1', title: 'レクタングル広告コード1', type: 'text', description: '広告コード等を貼り付ける欄です。空の場合は表示しません。' },
+
+    // ── 解答側 ────────────────────────
+    { name: 'answerImage', title: '正解画像（Answer Image）', type: 'image', options: { hotspot: true } },
+    { name: 'answerExplanation', title: '正解の解説', type: 'array', of: [{ type: 'block' }] },
+
+    // レクタングル広告コード2（任意）
+    { name: 'adCode2', title: 'レクタングル広告コード2', type: 'text', description: '広告コード等を貼り付ける欄です。空の場合は表示しません。' },
+
+    // 締め文（入稿がある場合のみ表示）
+    { name: 'closingMessage', title: '締めテキスト', type: 'string' },
+
+    // ── カテゴリ（最後に配置） ──────────
     {
       name: 'category',
       title: 'カテゴリ',
       type: 'reference',
       to: [{ type: 'category' }],
       validation: R => R.required()
-    },
-
-    // ── 問題側（この順でStudioに並びます） ────────────────
-    { name: 'mainImage', title: '問題画像（Main Image）', type: 'image', options: { hotspot: true }, validation: R => R.required() },
-
-    // ① 問題の補足
-    { name: 'problemDescription', title: '問題の補足', type: 'array', of: [{ type: 'block' }] },
-
-    // ② ヒント（新しい“枠”）…「問題の補足」と広告コード1の間に入れる想定
-    {
-      name: 'hints',
-      title: 'ヒント（複数可）',
-      type: 'array',
-      of: [{ type: 'block' }],
-      description: '短文1〜3個推奨。ヒントが入力されている場合はページ区切りのトリガーになります。'
-    },
-
-    // 旧互換（文字列）。表示側は「hints なければ hint を使う」フォールバックで参照
-    { name: 'hint', title: 'ヒント（旧・互換）', type: 'text', hidden: true },
-
-    // ── 解答側 ──────────────────────────────────────────
-    { name: 'answerImage', title: '正解画像（Answer Image）', type: 'image', options: { hotspot: true } },
-    { name: 'answerExplanation', title: '正解の解説', type: 'array', of: [{ type: 'block' }] },
-
-    // ③ 締め文（「正解への補足」と「カテゴリ」の間に出す想定）
-    {
-      name: 'closingMessage',
-      title: '締めテキスト',
-      type: 'string'
     }
   ]
 }


### PR DESCRIPTION
Studioをゼロから再構築: クイズ入稿に
- hints(PT配列), closingMessage(文字列)
- adCode1/2(広告コードテキスト)
- projectId/dataset を固定

※既存記事は再作成前提。デプロイ後、編集UIに新項目が表示されます。