### PR TITLE
Sanityクイズスキーマを指定項目に合わせて更新

### DIFF
--- a/sanity_debug.js
+++ b/sanity_debug.js
@@ -27,10 +27,14 @@ async function debugSanityData() {
       _type,
       _createdAt,
       title,
-      slug,
-      category,
-      questionImage,
-      answerImage
+      "slug": slug.current,
+      category->{ title, "slug": slug.current },
+      mainImage,
+      problemDescription,
+      hint,
+      answerImage,
+      answerExplanation,
+      closingMessage
     }`);
     console.log(`クイズ数: ${quizzes.length}`);
     console.log(JSON.stringify(quizzes, null, 2));
@@ -64,10 +68,14 @@ async function debugSanityData() {
     const sampleQuiz = await client.fetch(`*[_type == "quiz" && slug.current == "sample-quiz"][0]{
       _id,
       title,
-      slug,
-      category,
-      questionImage,
-      answerImage
+      "slug": slug.current,
+      category->{ title, "slug": slug.current },
+      mainImage,
+      problemDescription,
+      hint,
+      answerImage,
+      answerExplanation,
+      closingMessage
     }`);
     console.log(JSON.stringify(sampleQuiz, null, 2));
 

--- a/sanity_schemas_proposal.js
+++ b/sanity_schemas_proposal.js
@@ -12,7 +12,7 @@ export default {
       name: 'title',
       title: 'タイトル',
       type: 'string',
-      validation: Rule => Rule.required()
+      validation: (Rule) => Rule.required()
     },
     {
       name: 'slug',
@@ -22,7 +22,7 @@ export default {
         source: 'title',
         maxLength: 96
       },
-      validation: Rule => Rule.required()
+      validation: (Rule) => Rule.required()
     },
     {
       name: 'mainImage',
@@ -31,7 +31,7 @@ export default {
       options: {
         hotspot: true
       },
-      validation: Rule => Rule.required()
+      validation: (Rule) => Rule.required()
     },
     {
       name: 'problemDescription',
@@ -40,20 +40,37 @@ export default {
       of: [
         {
           type: 'block',
-          styles: [{title: 'Normal', value: 'normal'}],
+          styles: [{ title: '標準', value: 'normal' }],
           lists: [],
           marks: {
-            decorators: [{title: 'Strong', value: 'strong'}, {title: 'Emphasis', value: 'em'}],
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
             annotations: []
           }
         }
       ]
     },
     {
-      name: 'adCode1',
-      title: 'レクタングル広告コード1',
-      type: 'text',
-      description: 'AdSenseなどの広告コードをここに貼り付けます。'
+      name: 'hint',
+      title: 'ヒント',
+      description: '必要に応じて複数のヒントを追加できます。',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: '標準', value: 'normal' }],
+          lists: [],
+          marks: {
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
+            annotations: []
+          }
+        }
+      ]
     },
     {
       name: 'answerImage',
@@ -62,25 +79,41 @@ export default {
       options: {
         hotspot: true
       },
-      description: '2ページ目に表示される正解画像です。'
-    },
-    {
-      name: 'adCode2',
-      title: 'レクタングル広告コード2',
-      type: 'text',
-      description: 'AdSenseなどの広告コードをここに貼り付けます。空白の場合は表示されません。'
+      validation: (Rule) => Rule.required()
     },
     {
       name: 'answerExplanation',
-      title: '正解への補足テキスト',
+      title: '解説文',
       type: 'array',
       of: [
         {
           type: 'block',
-          styles: [{title: 'Normal', value: 'normal'}],
+          styles: [{ title: '標準', value: 'normal' }],
           lists: [],
           marks: {
-            decorators: [{title: 'Strong', value: 'strong'}, {title: 'Emphasis', value: 'em'}],
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
+            annotations: []
+          }
+        }
+      ]
+    },
+    {
+      name: 'closingMessage',
+      title: '締め文',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: '標準', value: 'normal' }],
+          lists: [],
+          marks: {
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
             annotations: []
           }
         }
@@ -90,8 +123,8 @@ export default {
       name: 'category',
       title: 'カテゴリ',
       type: 'reference',
-      to: [{type: 'category'}],
-      validation: Rule => Rule.required()
+      to: [{ type: 'category' }],
+      validation: (Rule) => Rule.required()
     }
   ]
 };
@@ -110,7 +143,17 @@ export const categorySchema = {
       name: 'title',
       title: 'タイトル',
       type: 'string',
-      validation: Rule => Rule.required()
+      validation: (Rule) => Rule.required()
+    },
+    {
+      name: 'slug',
+      title: 'スラッグ',
+      type: 'slug',
+      options: {
+        source: 'title',
+        maxLength: 96
+      },
+      validation: (Rule) => Rule.required()
     },
     {
       name: 'description',
@@ -126,19 +169,16 @@ export const categorySchema = {
 
   例:
   import {defineConfig} from 'sanity'
-  import {schemaTypes} from './schemas'
   import quiz from './schemas/quiz'
   import category from './schemas/category'
 
   export default defineConfig({
     // ...その他の設定
     schema: {
-      types: schemaTypes.concat([
+      types: [
         quiz,
         category
-      ]),
-    },
+      ]
+    }
   })
 */
-
-

--- a/scripts/get_quiz_by_slug.mjs
+++ b/scripts/get_quiz_by_slug.mjs
@@ -11,7 +11,7 @@ if(!slug){ console.error('usage: node scripts/get_quiz_by_slug.mjs <slug>'); pro
 const q=`*[_type=='quiz' && slug.current==$slug][0]{
   _id,_type,_updatedAt,title,"slug":slug.current,
   category->{title,"slug":slug.current},
-  problemDescription, hints, hint,
+  problemDescription, hint,
   mainImage{asset->{url}}, answerImage{asset->{url}}, answerExplanation
 }`
 const doc = await client.fetch(q,{slug})

--- a/scripts/setup_live_dataset.mjs
+++ b/scripts/setup_live_dataset.mjs
@@ -72,9 +72,9 @@ async function seed() {
       mainImage: q2Main,
       answerImage: q2Ans,
       problemDescription: pt('マッチ棒1本だけを別の場所へ移動して、式「8＋2＝6」を正しい等式に直してください。画像の中で“どの1本を動かすか”がポイントです。'),
-      hints: [],
+      hint: [],
       answerExplanation: pt('左の「8」から右上の縦1本を抜き、右の「6」の右上に移します。左は 8→6、右は 6→8。よって式は 6＋2＝8 となり、正解です。'),
-      closingMessage: ''
+      closingMessage: []
     },
     {
       _id: 'matchstick-quiz-1',
@@ -85,9 +85,9 @@ async function seed() {
       mainImage: q1Main,
       answerImage: q1Ans,
       problemDescription: pt('マッチ棒1本だけを別の場所へ移動して、式「9＋1＝8」を正しい等式に直してください。画像の中で“どの1本を動かすか”がポイントです。'),
-      hints: [],
+      hint: [],
       answerExplanation: pt('右の「8」から左下の縦1本を抜き、それを左の「9」の左下に移します。よって式は 8＋1＝9 となり、正解です。'),
-      closingMessage: ''
+      closingMessage: []
     }
   ]
 

--- a/src/routes/quiz/[category]/[slug]/+page.server.js
+++ b/src/routes/quiz/[category]/[slug]/+page.server.js
@@ -13,7 +13,6 @@ const QUERY = /* groq */ `
   category->{ title, "slug": slug.current },
   mainImage{ asset->{ url, metadata } },
   problemDescription,
-  hints,
   hint
 }`;
 

--- a/src/routes/quiz/[category]/[slug]/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/+page.svelte
@@ -5,6 +5,7 @@
   function renderPortableText(content) {
     if (!content) return '';
     if (typeof content === 'string') return content;
+    if (content?._type === 'block') return renderPortableText([content]);
     if (Array.isArray(content)) {
       return content
         .filter((b) => b?._type === 'block')
@@ -15,8 +16,23 @@
   }
 
   function textOrPortable(content) {
-    return typeof content === 'string' ? content : renderPortableText(content);
+    if (!content) return '';
+    if (typeof content === 'string') return content;
+    return renderPortableText(content);
   }
+
+  function normalizePortableArray(value) {
+    if (!value) return [];
+    if (Array.isArray(value)) return value;
+    return [value];
+  }
+
+  $: hintTexts = [
+    ...normalizePortableArray(quiz?.hint),
+    ...normalizePortableArray(quiz?.hints)
+  ]
+    .map((entry) => textOrPortable(entry)?.trim())
+    .filter(Boolean);
 </script>
 
 <svelte:head>
@@ -42,20 +58,13 @@
   {/if}
 
   <!-- ヒント -->
-  {#if Array.isArray(quiz.hints) && quiz.hints.length}
+  {#if hintTexts.length}
     <section style="margin:16px 0;">
       <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
       <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">
-        {#each quiz.hints as h}
-          <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(h)}</p>
+        {#each hintTexts as hintText, index (index)}
+          <p style="white-space:pre-line;line-height:1.8;">{hintText}</p>
         {/each}
-      </div>
-    </section>
-  {:else if textOrPortable(quiz.hint)}
-    <section style="margin:16px 0;">
-      <h2 style="font-size:1.25rem;margin:.5rem 0;">ヒント</h2>
-      <div style="margin-top:.5rem;background:#f8f9fa;padding:1rem;border-left:4px solid #ffc107;border-radius:8px;">
-        <p style="white-space:pre-line;line-height:1.8;">{textOrPortable(quiz.hint)}</p>
       </div>
     </section>
   {/if}

--- a/studio/schemaTypes/quiz.js
+++ b/studio/schemaTypes/quiz.js
@@ -1,47 +1,126 @@
 // studio/schemaTypes/quiz.js
-// 現行の管理画面をゼロから再構築（広告コード + ヒント複数 + 締め文 を含む）
 export default {
   name: 'quiz',
   title: 'クイズ',
   type: 'document',
   fields: [
-    // ── メタ ───────────────────────────
-    { name: 'title', title: 'タイトル', type: 'string', validation: R => R.required() },
+    // ── 基本情報 ─────────────────────────
+    {
+      name: 'title',
+      title: 'タイトル',
+      type: 'string',
+      validation: (Rule) => Rule.required()
+    },
     {
       name: 'slug',
       title: 'スラッグ',
       type: 'slug',
       options: { source: 'title', maxLength: 96 },
-      validation: R => R.required()
+      validation: (Rule) => Rule.required()
     },
 
-    // ── 問題側 ────────────────────────
-    { name: 'mainImage', title: '問題画像（Main Image）', type: 'image', options: { hotspot: true }, validation: R => R.required() },
-    { name: 'problemDescription', title: '問題の補足', type: 'array', of: [{ type: 'block' }] },
+    // ── 問題 ─────────────────────────────
+    {
+      name: 'mainImage',
+      title: '問題画像',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required()
+    },
+    {
+      name: 'problemDescription',
+      title: '問題の補足',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: '標準', value: 'normal' }],
+          lists: [],
+          marks: {
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
+            annotations: []
+          }
+        }
+      ]
+    },
+    {
+      name: 'hint',
+      title: 'ヒント',
+      description: '必要に応じて複数のヒントを追加できます。',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: '標準', value: 'normal' }],
+          lists: [],
+          marks: {
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
+            annotations: []
+          }
+        }
+      ]
+    },
 
-    // ヒント（複数可）
-    { name: 'hints', title: 'ヒント（複数可）', type: 'array', of: [{ type: 'block' }] },
+    // ── 解答 ─────────────────────────────
+    {
+      name: 'answerImage',
+      title: '正解画像',
+      type: 'image',
+      options: { hotspot: true },
+      validation: (Rule) => Rule.required()
+    },
+    {
+      name: 'answerExplanation',
+      title: '解説文',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: '標準', value: 'normal' }],
+          lists: [],
+          marks: {
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
+            annotations: []
+          }
+        }
+      ]
+    },
+    {
+      name: 'closingMessage',
+      title: '締め文',
+      type: 'array',
+      of: [
+        {
+          type: 'block',
+          styles: [{ title: '標準', value: 'normal' }],
+          lists: [],
+          marks: {
+            decorators: [
+              { title: '太字', value: 'strong' },
+              { title: '斜体', value: 'em' }
+            ],
+            annotations: []
+          }
+        }
+      ]
+    },
 
-    // レクタングル広告コード1（任意）
-    { name: 'adCode1', title: 'レクタングル広告コード1', type: 'text', description: '広告コード等を貼り付ける欄です。空の場合は表示しません。' },
-
-    // ── 解答側 ────────────────────────
-    { name: 'answerImage', title: '正解画像（Answer Image）', type: 'image', options: { hotspot: true } },
-    { name: 'answerExplanation', title: '正解の解説', type: 'array', of: [{ type: 'block' }] },
-
-    // レクタングル広告コード2（任意）
-    { name: 'adCode2', title: 'レクタングル広告コード2', type: 'text', description: '広告コード等を貼り付ける欄です。空の場合は表示しません。' },
-
-    // 締め文（入稿がある場合のみ表示）
-    { name: 'closingMessage', title: '締めテキスト', type: 'string' },
-
-    // ── カテゴリ（最後に配置） ──────────
+    // ── カテゴリ ─────────────────────────
     {
       name: 'category',
       title: 'カテゴリ',
       type: 'reference',
       to: [{ type: 'category' }],
-      validation: R => R.required()
+      validation: (Rule) => Rule.required()
     }
   ]
 }


### PR DESCRIPTION
## 概要
- クイズドキュメントのスキーマを指定項目（タイトル／問題画像／補足／ヒント／正解画像／解説文／締め文／カテゴリ）に揃え、ポータブルテキスト対応を整理
- クイズ取得系のサーバーコード・デバッグスクリプトを新スキーマに合わせて更新し、ヒント表示ロジックを統一
- サンプルデータ投入スクリプトを新フィールド構成に合わせて補正

## テスト
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c8f5231e2c832fb32583c53d721e14