### PR TITLE
Sanity Draftのプレビュー確認を改善

### DIFF
--- a/scripts/get_quiz_by_slug.mjs
+++ b/scripts/get_quiz_by_slug.mjs
@@ -1,15 +1,60 @@
 import { createClient } from '@sanity/client'
+
+const args = process.argv.slice(2)
+let identifier = null
+let usePreviewDrafts = false
+let dataset = process.env.SANITY_DATASET || 'production'
+
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index]
+
+  if (!arg.startsWith('-') && !identifier) {
+    identifier = arg
+    continue
+  }
+
+  if (arg === '--preview' || arg === '--draft' || arg === '-p') {
+    usePreviewDrafts = true
+    continue
+  }
+
+  if (arg === '--dataset' || arg === '-d') {
+    const nextValue = args[index + 1]
+    if (!nextValue || nextValue.startsWith('-')) {
+      console.error('`--dataset` オプションには値が必要です。')
+      process.exit(1)
+    }
+    dataset = nextValue
+    index += 1
+  }
+}
+
+if (!identifier) {
+  console.error('usage: node scripts/get_quiz_by_slug.mjs <slug|id> [--preview] [--dataset <name>]')
+  process.exit(1)
+}
+
+const perspective = usePreviewDrafts ? 'previewDrafts' : 'published'
+
 const client = createClient({
   projectId: process.env.SANITY_PROJECT_ID,
-  dataset: process.env.SANITY_DATASET || 'production',
+  dataset,
   apiVersion: process.env.SANITY_API_VERSION || '2024-01-01',
-  token: process.env.SANITY_READ_TOKEN || process.env.SANITY_WRITE_TOKEN,
-  useCdn: false
+  token:
+    process.env.SANITY_READ_TOKEN ||
+    process.env.SANITY_API_READ_TOKEN ||
+    process.env.SANITY_WRITE_TOKEN ||
+    process.env.SANITY_API_WRITE_TOKEN,
+  useCdn: false,
+  perspective
 })
-const slug = process.argv[2]
-if(!slug){ console.error('usage: node scripts/get_quiz_by_slug.mjs <slug>'); process.exit(1) }
-const q=`*[_type=='quiz' && slug.current==$slug][0]{
-  _id,_type,_updatedAt,title,"slug":slug.current,
+
+const query = `*[_type=='quiz' && (slug.current==$identifier || _id==$identifier)]|order(_updatedAt desc)[0]{
+  _id,
+  _type,
+  _updatedAt,
+  title,
+  "slug":slug.current,
   category->{title,"slug":slug.current},
   problemDescription,
   "hints": select(
@@ -17,7 +62,31 @@ const q=`*[_type=='quiz' && slug.current==$slug][0]{
     defined(hint) => [hint],
     []
   ),
-  mainImage{asset->{url}}, answerImage{asset->{url}}, answerExplanation
+  adCode1,
+  adCode2,
+  mainImage{asset->{url}},
+  answerImage{asset->{url}},
+  answerExplanation,
+  closingMessage
 }`
-const doc = await client.fetch(q,{slug})
-console.log(JSON.stringify(doc,null,2))
+
+try {
+  const doc = await client.fetch(query, { identifier })
+
+  if (!doc) {
+    console.error('指定したスラッグまたはIDのクイズが見つかりません。')
+    process.exit(1)
+  }
+
+  console.error(`dataset=${dataset} perspective=${perspective}`)
+
+  if (usePreviewDrafts) {
+    const source = doc._id?.startsWith('drafts.') ? 'draft' : 'published'
+    console.error(`プレビュー取得: ${source} を表示しています。`)
+  }
+
+  console.log(JSON.stringify(doc, null, 2))
+} catch (error) {
+  console.error('Sanityからの取得に失敗しました:', error.message)
+  process.exit(1)
+}

--- a/src/lib/fetchQuizzes.js
+++ b/src/lib/fetchQuizzes.js
@@ -31,7 +31,11 @@ export async function fetchQuizBySlug(slug) {
       "slug": slug.current,
       category->{ _id, title },
       problemDescription,
-      hints,
+      "hints": select(
+        defined(hints) => hints,
+        defined(hint) => [hint],
+        []
+      ),
       adCode1,
       mainImage,
       answerImage,

--- a/src/lib/portableText.js
+++ b/src/lib/portableText.js
@@ -1,0 +1,47 @@
+// src/lib/portableText.js
+// ポータブルテキストをプレーンテキストとして扱うためのユーティリティ関数群
+
+/**
+ * Sanityのポータブルテキスト（block配列）を\n * 改行区切りのプレーンテキストに変換します。
+ * @param {unknown} content
+ * @returns {string}
+ */
+export function renderPortableText(content) {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  if (content?._type === 'block') return renderPortableText([content]);
+  if (Array.isArray(content)) {
+    return content
+      .filter((block) => block?._type === 'block')
+      .map((block) =>
+        block?.children
+          ?.filter((child) => child?._type === 'span')
+          ?.map((child) => child.text)
+          .join('') || ''
+      )
+      .join('\n');
+  }
+  return '';
+}
+
+/**
+ * 文字列またはポータブルテキストをプレーンテキストとして返します。
+ * @param {unknown} content
+ * @returns {string}
+ */
+export function textOrPortable(content) {
+  if (!content) return '';
+  if (typeof content === 'string') return content;
+  return renderPortableText(content);
+}
+
+/**
+ * ポータブルテキストのエントリを配列に揃えます。
+ * @param {unknown} value
+ * @returns {unknown[]}
+ */
+export function normalizePortableArray(value) {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return [value];
+}

--- a/src/lib/sanity.server.js
+++ b/src/lib/sanity.server.js
@@ -3,13 +3,26 @@ import { createClient } from '@sanity/client';
 import imageUrlBuilder from '@sanity/image-url';
 import { env } from '$env/dynamic/private';
 
+const nodeEnv = env.NODE_ENV || 'production';
+const previewFlag = (env.SANITY_PREVIEW_DRAFTS || env.SANITY_PREVIEW || '').toLowerCase() === 'true';
+const dataset = env.SANITY_DATASET || env.PUBLIC_SANITY_DATASET || 'production';
+const token = [
+  env.SANITY_READ_TOKEN,
+  env.SANITY_API_READ_TOKEN,
+  env.SANITY_PREVIEW_TOKEN,
+  env.SANITY_WRITE_TOKEN,
+  env.SANITY_API_WRITE_TOKEN
+].find((value) => typeof value === 'string' && value.length > 0);
+const hasToken = Boolean(token);
+const enablePreviewDrafts = hasToken && (previewFlag || nodeEnv !== 'production');
+
 export const client = createClient({
-  projectId: env.SANITY_PROJECT_ID,
-  dataset: env.SANITY_DATASET || 'production',
+  projectId: env.SANITY_PROJECT_ID || env.PUBLIC_SANITY_PROJECT_ID,
+  dataset,
   apiVersion: env.SANITY_API_VERSION || '2024-01-01',
-  token: env.SANITY_READ_TOKEN,
+  token,
   useCdn: false,
-  perspective: 'published'
+  perspective: enablePreviewDrafts ? 'previewDrafts' : 'published'
 });
 
 const builder = imageUrlBuilder(client);

--- a/src/routes/quiz/[category]/[slug]/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/+page.svelte
@@ -1,31 +1,8 @@
 <script>
+  import { normalizePortableArray, textOrPortable } from '$lib/portableText.js';
+
   export let data;
   const { quiz } = data;
-
-  function renderPortableText(content) {
-    if (!content) return '';
-    if (typeof content === 'string') return content;
-    if (content?._type === 'block') return renderPortableText([content]);
-    if (Array.isArray(content)) {
-      return content
-        .filter((b) => b?._type === 'block')
-        .map((b) => b?.children?.filter((c) => c?._type === 'span')?.map((c) => c.text).join('') || '')
-        .join('\n');
-    }
-    return '';
-  }
-
-  function textOrPortable(content) {
-    if (!content) return '';
-    if (typeof content === 'string') return content;
-    return renderPortableText(content);
-  }
-
-  function normalizePortableArray(value) {
-    if (!value) return [];
-    if (Array.isArray(value)) return value;
-    return [value];
-  }
 
   $: hintTexts = [
     ...normalizePortableArray(quiz?.hints)

--- a/src/routes/quiz/[category]/[slug]/answer/+page.svelte
+++ b/src/routes/quiz/[category]/[slug]/answer/+page.svelte
@@ -1,18 +1,16 @@
 <script>
+  import { textOrPortable } from '$lib/portableText.js';
+
   export let data;
   const { quiz } = data;
 
-  function renderPT(content){
-    if (!content) return '';
-    if (typeof content === 'string') return content;
-    if (Array.isArray(content)){
-      return content
-        .filter(b=>b?._type==='block')
-        .map(b=> b.children?.filter(c=>c?._type==='span')?.map(c=>c.text).join('') || '')
-        .join('\n');
-    }
-    return '';
-  }
+  const FALLBACK_CLOSING_MESSAGE =
+    'このシリーズは毎日更新。明日も新作を公開します。ブックマークしてまた挑戦してください！';
+
+  $: answerExplanationText = textOrPortable(quiz?.answerExplanation);
+  $: hasAnswerExplanation = Boolean(answerExplanationText?.trim());
+  $: closingTextValue = textOrPortable(quiz?.closingMessage)?.trim();
+  $: closingText = closingTextValue || FALLBACK_CLOSING_MESSAGE;
 </script>
 
 <svelte:head>
@@ -28,13 +26,17 @@
     </div>
   {/if}
 
-  {#if renderPT(quiz.answerExplanation)}
+  {#if hasAnswerExplanation}
     <section style="margin:16px 0;">
       <h2 style="font-size:1.25rem;margin:.5rem 0;">解説</h2>
-      <p style="white-space:pre-line;line-height:1.8;">{renderPT(quiz.answerExplanation)}</p>
+      <p style="white-space:pre-line;line-height:1.8;">{answerExplanationText}</p>
     </section>
   {/if}
 
+  <section style="margin:16px 0;">
+    <h2 style="font-size:1.25rem;margin:.5rem 0;">締め文</h2>
+    <p style="white-space:pre-line;line-height:1.8;">{closingText}</p>
+  </section>
 
   <div style="text-align:center;margin:24px 0;">
     <a


### PR DESCRIPTION
## Summary
- サーバー側のSanityクライアントで読み取りトークンが未設定でも書き込みトークンを使ってドラフトプレビューを有効化できるようにしました
- クイズ表示/正解ページでポータブルテキストの整形処理を共通化し、締め文や解説のドラフト内容を正しく表示できるようにしました
- `fetchQuizBySlug` でも旧 `hint` フィールドを含めてヒントを配列化し、ドラフト確認時の不整合を解消しました
- `scripts/get_quiz_by_slug.mjs` にデータセット指定やID検索対応を追加し、プレビュー設定の競合が起きないようにしました

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c950081f3c832fb8187573a72cd32f