### PR TITLE
Sanity デバッグ用ルートのプロジェクトIDを統一

### DIFF
--- a/src/routes/quiz/_debug_where/[slug]/+server.ts
+++ b/src/routes/quiz/_debug_where/[slug]/+server.ts
@@ -12,10 +12,7 @@ const mk = (projectId: string) =>
     perspective: 'published'
   });
 
-const clients = [
-  { label: 'quljge22', client: mk('quljge22') },
-  { label: 'dxl04rd4', client: mk('dxl04rd4') }, // 画像で使われていたID
-];
+const clients = [{ label: 'quljge22', client: mk('quljge22') }];
 
 const Q = `*[defined(slug.current) && slug.current==$slug][0]{_id,_type,title,slug,_updatedAt}`;
 


### PR DESCRIPTION
## Summary
- quiz デバッグ用 API ルートから旧プロジェクト ID (dxl04rd4) への参照を削除し、`quljge22` のみを問い合わせるよう統一しました。

## Testing
- `SANITY_PROJECT_ID=quljge22 SANITY_DATASET=production npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c98d310c58832f9a9f2166daa50e09