### PR TITLE
Codespaces 用 devcontainer と起動前ガードを追加

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,40 +1,9 @@
 {
-  "name": "SvelteKit + Sanity Development Environment",
-  "image": "mcr.microsoft.com/devcontainers/javascript-node:1-20-bullseye",
+  "name": "noutore-biyori",
+  "image": "mcr.microsoft.com/devcontainers/node:20",
   "features": {
-    "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/devcontainers/features/git:1": {}
+    "ghcr.io/devcontainers/features/pnpm:2": {}
   },
-  "customizations": {
-    "vscode": {
-      "extensions": [
-        "svelte.svelte-vscode",
-        "bradlc.vscode-tailwindcss",
-        "esbenp.prettier-vscode",
-        "ms-vscode.vscode-typescript-next",
-        "ms-vscode.vscode-json",
-        "GitHub.copilot",
-        "GitHub.copilot-chat",
-        "ms-vscode.live-server",
-        "formulahendry.auto-rename-tag",
-        "christian-kohler.path-intellisense",
-        "ms-vscode.vscode-eslint"
-      ],
-      "settings": {
-        "editor.formatOnSave": true,
-        "editor.defaultFormatter": "esbenp.prettier-vscode",
-        "editor.codeActionsOnSave": {
-          "source.fixAll.eslint": "explicit"
-        },
-        "typescript.preferences.importModuleSpecifier": "relative",
-        "svelte.enable-ts-plugin": true,
-        "files.associations": {
-          "*.svelte": "svelte"
-        }
-      }
-    }
-  },
-  "postCreateCommand": "npm install -g pnpm && pnpm install",
   "forwardPorts": [5173, 3333],
   "portsAttributes": {
     "5173": {
@@ -46,5 +15,5 @@
       "onAutoForward": "notify"
     }
   },
-  "remoteUser": "node"
+  "postCreateCommand": "pnpm run postcreate"
 }

--- a/README.md
+++ b/README.md
@@ -3,16 +3,44 @@
 
 ## セットアップ
 
-```bash
-# 環境変数ファイルを作成
-cp .env.local.example .env.local
+### 環境変数ファイルの作成
 
-# 依存関係をインストール
+```bash
+cp .env.local.example .env.local
+```
+
+### 依存関係のインストール
+
+```bash
+# ルートの依存関係をインストール
 pnpm install
 
-# 開発サーバーを起動
+# Sanity Studio 側の依存関係もインストール
+pnpm --dir studio install
+```
+
+Codespaces や Dev Container で開いた場合は、`.devcontainer/devcontainer.json` の `postCreateCommand` により `pnpm run postcreate` が実行され、上記のインストール処理が自動で行われます。ローカルでの初回セットアップ時に手動でまとめて行う場合は以下を実行してください。
+
+```bash
+pnpm run postcreate
+```
+
+## 開発サーバーの起動
+
+以下のコマンドで SvelteKit（ポート 5173）と Sanity Studio（ポート 3333）が同時に立ち上がります。
+
+```bash
 pnpm dev
 ```
+
+必要に応じて片方だけ起動したい場合は次のコマンドを利用できます。
+
+```bash
+pnpm run dev:web     # SvelteKit のみ起動
+pnpm run dev:studio  # Sanity Studio のみ起動
+```
+
+開発サーバー起動前に `scripts/preflight.mjs` が実行され、必須環境変数と Git 作業ツリーの状態、Sanity 関連の迷子ファイルをチェックします。エラー内容を解消した上で再度コマンドを実行してください。
 
 ### 環境変数について
 

--- a/package.json
+++ b/package.json
@@ -5,12 +5,17 @@
   "main": "script.js",
   "type": "module",
   "scripts": {
-    "dev": "vite dev",
+    "predev": "node scripts/preflight.mjs",
+    "dev": "pnpm run dev:all",
+    "dev:all": "npm-run-all --parallel dev:web dev:studio",
+    "dev:web": "vite dev --host 0.0.0.0 --port 5173",
+    "dev:studio": "pnpm --dir studio dev -- --host 0.0.0.0 --port 3333",
     "build": "vite build",
     "preview": "vite preview",
-"test": "echo \"no tests yet\" && exit 0",
-"format": "pnpm dlx prettier --write .",
-"format:check": "pnpm dlx prettier --check ."
+    "postcreate": "pnpm install && pnpm --dir studio install",
+    "test": "echo \"no tests yet\" && exit 0",
+    "format": "pnpm dlx prettier --write .",
+    "format:check": "pnpm dlx prettier --check ."
   },
   "repository": {
     "type": "git",
@@ -31,6 +36,8 @@
     "vite": "^7.1.0"
   },
   "devDependencies": {
+    "npm-run-all": "npm:npm-run-all2@^6.2.2",
+    "rimraf": "^6.0.1",
     "svelte": "^5.38.3"
   }
 }

--- a/scripts/preflight.mjs
+++ b/scripts/preflight.mjs
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+import { execSync } from 'node:child_process';
+import { readdirSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import process from 'node:process';
+import { fileURLToPath } from 'node:url';
+
+const requiredEnv = ['SANITY_PROJECT_ID', 'SANITY_DATASET', 'SANITY_API_VERSION'];
+const missing = requiredEnv.filter((key) => {
+  const value = process.env[key];
+  return value === undefined || value === '';
+});
+
+if (missing.length > 0) {
+  console.error(`必須環境変数が未設定です: ${missing.join(', ')}`);
+  process.exit(1);
+}
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, '..');
+const schemaDir = path.join(repoRoot, 'studio', 'schemas');
+
+if (existsSync(schemaDir)) {
+  const strayFiles = readdirSync(schemaDir, { withFileTypes: true })
+    .filter((entry) => entry.isFile())
+    .map((entry) => entry.name)
+    .filter((name) => /^sanity\..*\.ts$/u.test(name));
+
+  if (strayFiles.length > 0) {
+    console.error(
+      `studio/schemas 内で Sanity の設定ファイルと思われる迷子ファイルを検出しました: ${strayFiles.join(', ')}`
+    );
+    process.exit(1);
+  }
+}
+
+try {
+  const result = execSync('git clean -fdX -n', {
+    cwd: repoRoot,
+    encoding: 'utf8'
+  }).trim();
+
+  if (result.length > 0) {
+    console.warn('git clean -fdX -n の結果、削除対象となるファイルが見つかりました:\n' + result);
+  } else {
+    console.warn('git clean -fdX -n の結果、削除対象はありません。');
+  }
+} catch (error) {
+  console.warn('git clean -fdX -n の実行に失敗しました。', error);
+}


### PR DESCRIPTION
## Summary
- Node 20 / pnpm ベースの devcontainer を追加し、Codespaces / Dev Container 用のポート自動フォワードと postCreateCommand を設定
- 開発前チェック用の `scripts/preflight.mjs` を追加し、`pnpm dev` 実行時に Sanity 用の必須環境変数や迷子ファイル、`git clean -fdX -n` の結果を確認
- `npm-run-all` と `rimraf` を導入し、SvelteKit と Sanity Studio を並行起動する `dev:web` / `dev:studio` / `dev:all` スクリプトや README の手順を整備

## Testing
- `SANITY_PROJECT_ID=demo SANITY_DATASET=production SANITY_API_VERSION=2024-01-01 node scripts/preflight.mjs`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68ca2a10ebec832f843d15d27d5a9695