### PR TITLE
fix: configure vercel adapter for deployment

### DIFF
--- a/.github/workflows/update-lock.yml
+++ b/.github/workflows/update-lock.yml
@@ -27,10 +27,23 @@ jobs:
       - name: Install dependencies (update lockfile)
         run: pnpm install --no-frozen-lockfile
 
+      - name: Check for lockfile changes
+        id: lockfile_status
+        run: |
+          if git status --porcelain pnpm-lock.yaml | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Commit updated lockfile
+        if: steps.lockfile_status.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pnpm-lock.yaml
-          git commit -m "chore: update pnpm-lock.yaml via Actions" || echo "No changes"
-          git push origin HEAD:${{ inputs.target_ref }}
+          git commit -m "chore: update pnpm-lock.yaml via Actions"
+
+      - name: Push changes
+        if: steps.lockfile_status.outputs.changed == 'true'
+        run: git push origin HEAD:${{ inputs.target_ref }}

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-"test": "echo \"no tests yet\" && exit 0",
-"format": "pnpm dlx prettier --write .",
-"format:check": "pnpm dlx prettier --check ."
+    "test": "echo \"no tests yet\" && exit 0",
+    "format": "pnpm dlx prettier --write .",
+    "format:check": "pnpm dlx prettier --check ."
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "vite": "^7.1.0"
   },
   "devDependencies": {
-    "svelte": "^5.38.3"
+    "svelte": "^5.38.3",
+    "@sveltejs/adapter-vercel": "^5.3.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-    "test": "echo \"no tests yet\" && exit 0",
-    "format": "pnpm dlx prettier --write .",
-    "format:check": "pnpm dlx prettier --check ."
+"test": "echo \"no tests yet\" && exit 0",
+"format": "pnpm dlx prettier --write .",
+"format:check": "pnpm dlx prettier --check ."
   },
   "repository": {
     "type": "git",
@@ -31,7 +31,6 @@
     "vite": "^7.1.0"
   },
   "devDependencies": {
-    "svelte": "^5.38.3",
-    "@sveltejs/adapter-vercel": "^5.3.2"
+    "svelte": "^5.38.3"
   }
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,13 +1,13 @@
-import adapter from '@sveltejs/adapter-vercel';
+import adapter from '@sveltejs/adapter-auto';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  kit: {
-    adapter: adapter(),
-    files: {
-      appTemplate: 'src/app.html' // This path is relative to the project root
-    }
-  }
+       kit: {
+               adapter: adapter(),
+               files: {
+                       appTemplate: 'src/app.html' // This path is relative to the project root
+               }
+       }
 };
 
 export default config;

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,15 +1,13 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-vercel';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter(),
-		files: {
-			appTemplate: 'src/app.html' // This path is relative to the project root
-		}
-	}
+  kit: {
+    adapter: adapter(),
+    files: {
+      appTemplate: 'src/app.html' // This path is relative to the project root
+    }
+  }
 };
 
 export default config;
-
-


### PR DESCRIPTION
## Summary
- add @sveltejs/adapter-vercel to the dev dependencies for the Vercel adapter
- update the Svelte config to use the Vercel adapter and retain the app template mapping

## Testing
- pnpm install *(fails: registry access blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cada253594832f999a85f35cddcf93