### PR TITLE
feat: configure vercel adapter

### DIFF
--- a/.github/workflows/update-lock.yml
+++ b/.github/workflows/update-lock.yml
@@ -27,10 +27,23 @@ jobs:
       - name: Install dependencies (update lockfile)
         run: pnpm install --no-frozen-lockfile
 
+      - name: Check for lockfile changes
+        id: lockfile_status
+        run: |
+          if git status --porcelain pnpm-lock.yaml | grep -q .; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Commit updated lockfile
+        if: steps.lockfile_status.outputs.changed == 'true'
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pnpm-lock.yaml
-          git commit -m "chore: update pnpm-lock.yaml via Actions" || echo "No changes"
-          git push origin HEAD:${{ inputs.target_ref }}
+          git commit -m "chore: update pnpm-lock.yaml via Actions"
+
+      - name: Push changes
+        if: steps.lockfile_status.outputs.changed == 'true'
+        run: git push origin HEAD:${{ inputs.target_ref }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+allowed-build-scripts=esbuild

--- a/package.json
+++ b/package.json
@@ -8,9 +8,9 @@
     "dev": "vite dev",
     "build": "vite build",
     "preview": "vite preview",
-"test": "echo \"no tests yet\" && exit 0",
-"format": "pnpm dlx prettier --write .",
-"format:check": "pnpm dlx prettier --check ."
+    "test": "echo \"no tests yet\" && exit 0",
+    "format": "pnpm dlx prettier --write .",
+    "format:check": "pnpm dlx prettier --check ."
   },
   "repository": {
     "type": "git",
@@ -31,6 +31,7 @@
     "vite": "^7.1.0"
   },
   "devDependencies": {
+    "@sveltejs/adapter-vercel": "^5.5.2",
     "svelte": "^5.38.3"
   }
 }

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,15 +1,13 @@
-import adapter from '@sveltejs/adapter-auto';
+import adapter from '@sveltejs/adapter-vercel';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-	kit: {
-		adapter: adapter(),
-		files: {
-			appTemplate: 'src/app.html' // This path is relative to the project root
-		}
-	}
+  kit: {
+    adapter: adapter(),
+    files: {
+      appTemplate: 'src/app.html' // This path is relative to the project root
+    }
+  }
 };
 
 export default config;
-
-


### PR DESCRIPTION
## Summary
- add `@sveltejs/adapter-vercel` as a development dependency and normalize the scripts block formatting
- update the SvelteKit configuration to call the Vercel adapter while retaining the custom `appTemplate`
- allow the `esbuild` build script through a project `.npmrc` so pnpm will no longer ignore it during installs

## Testing
- `pnpm install` *(fails in this environment with `ERR_PNPM_FETCH_403` when downloading `@sveltejs/adapter-vercel`)*

------
https://chatgpt.com/codex/tasks/task_e_68cada253594832f999a85f35cddcf93