### PR TITLE
Add GitHub Actions workflow for Sanity deploy

### DIFF
--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -1,0 +1,45 @@
+name: Deploy Sanity schema
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'studio/**'
+      - '.github/workflows/deploy-sanity.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install pnpm
+        run: npm install -g pnpm
+
+      - name: Install dependencies (studio)
+        working-directory: studio
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Authenticate with Sanity
+        run: npx -y sanity@latest login --with-token
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+
+      - name: Deploy schema to Sanity
+        working-directory: studio
+        env:
+          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
+        run: >-
+          npx -y sanity@latest deploy
+          noutore-biyori-studio-main
+          --project quljge22
+          --dataset production
+          --no-open

--- a/README.md
+++ b/README.md
@@ -110,3 +110,10 @@ pnpm -C studio exec sanity deploy
 - デプロイ前に Sanity プロジェクト設定から本番ドメインを CORS の許可リストへ追加してください。
 - デプロイが完了するとホスティング URL が表示されます（例: `https://<project-id>.sanity.studio/`）。
 - Vercel の本番サイトと相互に通信する場合、必要に応じて追加の CORS 設定を行ってください。
+
+#### GitHub Actions による自動デプロイ
+
+- `main` ブランチへのプッシュ、または手動トリガー（`workflow_dispatch`）で `.github/workflows/deploy-sanity.yml` が実行され、Sanity Studio が自動的に再デプロイされます。
+- リポジトリの Secrets に `SANITY_AUTH_TOKEN` を登録してください。Sanity の [Manage project tokens](https://www.sanity.io/manage) から **Deploy Studio** 権限以上を持つトークンを発行し、`Settings > Secrets and variables > Actions > New repository secret` で `SANITY_AUTH_TOKEN` として保存します。
+- ワークフローでは `noutore-biyori-studio-main` ホストに対して `sanity deploy` を実行し、`projectId: quljge22` / `dataset: production` のスキーマを常に最新化します。
+- GitHub Actions の実行が成功したら、Sanity Studio のホスティング URL（例: `https://noutore-biyori-studio-main.sanity.studio/`）を開き、スキーマの更新内容（フィールド追加/変更など）が反映されているか確認してください。


### PR DESCRIPTION
## Summary
- add an automated workflow that deploys Sanity Studio when changes are pushed to main or triggered manually
- document the required SANITY_AUTH_TOKEN secret and the verification flow in the README

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd7e8d0c0c832f8a720aa62f0969bf