### PR TITLE
fix: clean hosted sanity deploy workflow

### DIFF
--- a/.github/workflows/deploy-sanity.yml
+++ b/.github/workflows/deploy-sanity.yml
@@ -1,24 +1,13 @@
 name: Deploy Sanity Studio
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - 'studio/**'
-      - '.github/workflows/deploy-sanity.yml'
-  workflow_dispatch: {}
+  workflow_dispatch:
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-codex/fix-deployment-issues-for-sanity-studio-gkhqn1
-
-codex/fix-deployment-issues-for-sanity-studio-anrlel
-
     env:
       SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
-main
 
     steps:
       - name: Checkout
@@ -40,24 +29,9 @@ main
 
       - name: Deploy Sanity Studio (hosted)
         working-directory: studio
-codex/fix-deployment-issues-for-sanity-studio-gkhqn1
-        env:
-          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
-
-codex/fix-deployment-issues-for-sanity-studio-anrlel
-        env:
-          SANITY_AUTH_TOKEN: ${{ secrets.SANITY_AUTH_TOKEN }}
-main
-
         run: |
           npx --yes sanity@latest deploy \
             --project quljge22 \
             --dataset production \
             --host noutore-biyori-studio-main \
-codex/fix-deployment-issues-for-sanity-studio-gkhqn1
-            --token "$SANITY_AUTH_TOKEN" \
-
-codex/fix-deployment-issues-for-sanity-studio-anrlel
-            --token "$SANITY_AUTH_TOKEN" \
-main
             --yes


### PR DESCRIPTION
## Summary
- clean up the Sanity Studio deployment workflow and restrict it to manual runs
- ensure the hosted deployment uses the `noutore-biyori-studio-main` host flag without redundant tokens

## Testing
- not run (CIのみ)


------
https://chatgpt.com/codex/tasks/task_e_68d3c77f6688832f8d6fe26d71d5e65f