### PR TITLE
Fix: ヘッダーロゴを正しい画像に戻す

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -35,7 +35,7 @@
 <svelte:head>
   <title>{seo.title}</title>
   <link rel="preconnect" href="https://cdn.sanity.io" crossorigin />
-  <link rel="preload" href="/logo.svg" as="image" type="image/svg+xml" />
+  <link rel="preload" href="/logo.png" as="image" type="image/png" />
   {#if seo.description}
     <meta name="description" content={seo.description} />
   {/if}
@@ -100,7 +100,7 @@
   <div class="header-content">
     <a href="/" class="logo-section" aria-label="脳トレ日和 トップページ">
       <img
-        src="/logo.svg"
+        src="/logo.png"
         alt="脳トレ日和"
         class="logo-image"
         width="80"


### PR DESCRIPTION
## Summary
- ヘッダーのロゴ画像を PNG に戻し、想定外の差し替えが起きないようにしました
- プリロード対象も PNG に合わせて更新しました

## Testing
- pnpm build ※Sanity API へのアクセスが遮断されている環境のため多数の 403 エラーが発生しますが、ビルド自体は完了します

------
https://chatgpt.com/codex/tasks/task_e_68d4d0b48acc832f816f559fc24a7238