### PR TITLE
Fix: Normalize quiz category reference input

### DIFF
--- a/studio/.npmrc
+++ b/studio/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/

--- a/studio/package.json
+++ b/studio/package.json
@@ -10,6 +10,7 @@
     "@sanity/vision": "latest",
     "react": "18.x",
     "react-dom": "18.x",
-    "sanity": "latest"
+    "sanity": "latest",
+    "styled-components": "6.1.19"
   }
 }

--- a/studio/schemas/quiz.js
+++ b/studio/schemas/quiz.js
@@ -1,4 +1,23 @@
 // studio/schemas/quiz.js
+import {useEffect} from 'react'
+import {set, unset} from 'sanity'
+
+function CategoryReferenceInput(props) {
+  const {value, onChange} = props
+
+  useEffect(() => {
+    if (Array.isArray(value)) {
+      if (value.length > 0 && value[0]) {
+        onChange(set(value[0]))
+      } else {
+        onChange(unset())
+      }
+    }
+  }, [value, onChange])
+
+  return props.renderDefault(props)
+}
+
 export default {
   name: 'quiz',
   title: 'クイズ',
@@ -132,7 +151,8 @@ export default {
       title: 'カテゴリ',
       type: 'reference',
       to: [{ type: 'category' }],
-      validation: (Rule) => Rule.required()
+      validation: (Rule) => Rule.required(),
+      components: { input: CategoryReferenceInput }
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add a custom input component that normalizes legacy array values into a single reference so the quiz category field stays usable
- pin styled-components via package.json and add a local .npmrc to explicitly use the public npm registry to satisfy the Sanity CLI dependency check

## Testing
- `CI=1 pnpm exec sanity build` *(fails: Rollup cannot resolve `styled-components` because the package cannot be downloaded in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f5d64f60832faddcd293a652ba5a