### PR TITLE
Fix Sanity article pages by disabling global prerender

### DIFF
--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,7 +1,5 @@
 import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
 
-export const prerender = true;
-
 const CATEGORY_QUERY = /* groq */ `
 *[_type == "category" && defined(slug.current)] | order(title asc) {
   title,


### PR DESCRIPTION
## Summary
- remove the global prerender flag from the root layout so Sanity-backed pages render via SSR

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9e58b8ac4832f99f577239770931e