### PR TITLE
Fix quiz detail page fetching from Sanity

### DIFF
--- a/src/lib/utils/slug.js
+++ b/src/lib/utils/slug.js
@@ -51,13 +51,12 @@ export const createSlugQueryPayload = (value) => {
   const lowerCandidates = unique(candidates.map((entry) => entry.toLowerCase()));
   return { candidates, lowerCandidates };
 };
-codex/fix-404-error-on-article-page-migngy
 
 export const mergeSlugCandidateLists = (...lists) => {
   const seen = new Set();
   const merged = [];
   for (const list of lists) {
-    if (!list) continue;
+    if (!Array.isArray(list)) continue;
     for (const value of list) {
       if (typeof value !== 'string') continue;
       const trimmed = value.trim();
@@ -69,5 +68,3 @@ export const mergeSlugCandidateLists = (...lists) => {
   }
   return merged;
 };
-
-main

--- a/src/routes/quiz/[slug]/+page.server.js
+++ b/src/routes/quiz/[slug]/+page.server.js
@@ -1,10 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { client, urlFor, shouldSkipSanityFetch } from '$lib/sanity.server.js';
-codex/fix-404-error-on-article-page-migngy
 import { createSlugQueryPayload, mergeSlugCandidateLists } from '$lib/utils/slug.js';
-
-import { createSlugQueryPayload } from '$lib/utils/slug.js';
-main
 import { SITE } from '$lib/config/site.js';
 import { createPageSeo, portableTextToPlain } from '$lib/seo.js';
 
@@ -29,11 +25,11 @@ const QUIZ_QUERY = /* groq */ `
   "slug": slug.current,
   category->{ title, "slug": slug.current },
   mainImage{
-    ..., 
+    ...,
     asset->{ url, metadata }
   },
   problemImage{
-    ..., 
+    ...,
     asset->{ url, metadata }
   },
   problemDescription,
@@ -161,7 +157,6 @@ export const load = async (event) => {
   }
 
   try {
-codex/fix-404-error-on-article-page-migngy
     let doc = await client.fetch(QUIZ_QUERY, {
       slugCandidates,
       lowerSlugCandidates
@@ -175,7 +170,7 @@ codex/fix-404-error-on-article-page-migngy
           slugCandidates,
           resolvedPayload.candidates,
           [resolved.slug],
-          [resolved.id]
+          resolved?.id ? [resolved.id] : []
         );
         const nextLowerCandidates = mergeSlugCandidateLists(
           lowerSlugCandidates,
@@ -188,12 +183,6 @@ codex/fix-404-error-on-article-page-migngy
         });
       }
     }
-
-    const doc = await client.fetch(QUIZ_QUERY, {
-      slugCandidates,
-      lowerSlugCandidates
-    });
-main
 
     if (!doc) {
       throw error(404, 'Not found');

--- a/src/routes/quiz/[slug]/answer/+page.server.js
+++ b/src/routes/quiz/[slug]/answer/+page.server.js
@@ -1,10 +1,6 @@
 import { error } from '@sveltejs/kit';
 import { client, urlFor, shouldSkipSanityFetch } from '$lib/sanity.server.js';
-codex/fix-404-error-on-article-page-migngy
 import { createSlugQueryPayload, mergeSlugCandidateLists } from '$lib/utils/slug.js';
-
-import { createSlugQueryPayload } from '$lib/utils/slug.js';
-main
 import { SITE } from '$lib/config/site.js';
 import { createPageSeo, portableTextToPlain } from '$lib/seo.js';
 
@@ -150,11 +146,11 @@ export const load = async (event) => {
   }
 
   try {
-codex/fix-404-error-on-article-page-migngy
     let doc = await client.fetch(QUERY, {
       slugCandidates,
       lowerSlugCandidates
     });
+
     if (!doc) {
       const resolved = await resolveSlugFromCatalog(slugCandidates, lowerSlugCandidates);
       if (resolved?.slug) {
@@ -163,7 +159,7 @@ codex/fix-404-error-on-article-page-migngy
           slugCandidates,
           resolvedPayload.candidates,
           [resolved.slug],
-          [resolved.id]
+          resolved?.id ? [resolved.id] : []
         );
         const nextLowerCandidates = mergeSlugCandidateLists(
           lowerSlugCandidates,
@@ -177,11 +173,6 @@ codex/fix-404-error-on-article-page-migngy
       }
     }
 
-    const doc = await client.fetch(QUERY, {
-      slugCandidates,
-      lowerSlugCandidates
-    });
-main
     if (!doc) {
       throw error(404, 'Not found');
     }


### PR DESCRIPTION
## Summary
- fix the quiz detail and answer loaders so Sanity slugs resolve correctly
- clean the slug utility helper to avoid invalid candidate lists

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68da1237edc4832f807ae5f90da19bcb