### PR TITLE
Handle legacy quiz ID URLs via slug catalog

### DIFF
--- a/src/lib/fetchQuizzes.js
+++ b/src/lib/fetchQuizzes.js
@@ -3,7 +3,7 @@ import { client } from './sanity.server.js';
 
 export async function fetchAllQuizzes() {
   const query = /* groq */ `
-    *[_type == "quiz"] | order(_createdAt desc) {
+    *[_type == "quiz" && !(_id in path("drafts.**"))] | order(_createdAt desc) {
       _id,
       title,
       "slug": slug.current,
@@ -25,7 +25,7 @@ export async function fetchAllQuizzes() {
 
 export async function fetchQuizBySlug(slug) {
   const query = /* groq */ `
-    *[_type == "quiz" && (slug.current == $slug || _id == $slug)][0]{
+    *[_type == "quiz" && slug.current == $slug && !(_id in path("drafts.**"))][0]{
       _id,
       title,
       "slug": slug.current,
@@ -53,7 +53,7 @@ export async function fetchQuizBySlug(slug) {
 
 export async function fetchQuizzesByCategory(category) {
   const query = /* groq */ `
-    *[_type == "quiz" && ((defined(category._ref) && category->title == $category) || (!defined(category._ref) && category == $category))] | order(_createdAt desc) {
+    *[_type == "quiz" && !(_id in path("drafts.**")) && ((defined(category._ref) && category->title == $category) || (!defined(category._ref) && category == $category))] | order(_createdAt desc) {
       _id,
       title,
       "slug": slug.current,

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,7 +1,7 @@
 import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
 
 const CATEGORY_QUERY = /* groq */ `
-*[_type == "category" && defined(slug.current)] | order(title asc) {
+*[_type == "category" && defined(slug.current) && !(_id in path("drafts.**"))] | order(title asc) {
   title,
   "slug": slug.current
 }`;

--- a/src/routes/+page.server.js
+++ b/src/routes/+page.server.js
@@ -6,7 +6,7 @@ import { createPageSeo } from '$lib/seo.js';
 export const prerender = false;
 
 const QUIZZES_QUERY = /* groq */ `
-*[_type == "quiz" && defined(slug.current)] | order(_createdAt desc) {
+*[_type == "quiz" && defined(slug.current) && !(_id in path("drafts.**"))] | order(_createdAt desc) {
   _id,
   title,
   "slug": slug.current,

--- a/src/routes/category/[slug]/+page.server.js
+++ b/src/routes/category/[slug]/+page.server.js
@@ -5,19 +5,19 @@ import { createCategoryDescription, createPageSeo } from '$lib/seo.js';
 export const prerender = false;
 
 const CATEGORY_SLUGS_QUERY = /* groq */ `
-*[_type == "category" && defined(slug.current)]{
+*[_type == "category" && defined(slug.current) && !(_id in path("drafts.**"))]{
   "slug": slug.current
 }`;
 
 const CATEGORY_QUERY = /* groq */ `
-*[_type == "category" && slug.current == $slug][0]{
+*[_type == "category" && slug.current == $slug && !(_id in path("drafts.**"))][0]{
   title,
   "slug": slug.current,
   description
 }`;
 
 const QUIZZES_BY_CATEGORY_QUERY = /* groq */ `
-*[_type == "quiz" && defined(slug.current) && (
+*[_type == "quiz" && defined(slug.current) && !(_id in path("drafts.**")) && (
   (defined(category._ref) && category->slug.current == $slug) ||
   (!defined(category._ref) && defined(category.slug.current) && category.slug.current == $slug) ||
   (!defined(category._ref) && defined(category) && (category == $categoryTitle || category == $slug)) ||

--- a/src/routes/quiz/+page.server.js
+++ b/src/routes/quiz/+page.server.js
@@ -4,7 +4,7 @@ import { createPageSeo } from '$lib/seo.js';
 export const prerender = false;
 
 const QUIZZES_QUERY = /* groq */ `
-*[_type == "quiz" && defined(slug.current)] | order(_createdAt desc) {
+*[_type == "quiz" && defined(slug.current) && !(_id in path("drafts.**"))] | order(_createdAt desc) {
   _id,
   title,
   "slug": slug.current,

--- a/src/routes/quiz/[slug]/+page.server.js
+++ b/src/routes/quiz/[slug]/+page.server.js
@@ -1,23 +1,19 @@
 import { error } from '@sveltejs/kit';
 import { client, urlFor, shouldSkipSanityFetch } from '$lib/sanity.server.js';
-import { createSlugQueryPayload, mergeSlugCandidateLists } from '$lib/utils/slug.js';
+import { createSlugQueryPayload } from '$lib/utils/slug.js';
 import { SITE } from '$lib/config/site.js';
 import { createPageSeo, portableTextToPlain } from '$lib/seo.js';
 
 export const prerender = false;
 
 const QUIZ_SLUGS_QUERY = /* groq */ `
-*[_type == "quiz" && defined(slug.current)]{
+*[_type == "quiz" && defined(slug.current) && !(_id in path("drafts.**"))]{
   _id,
   "slug": slug.current
 }`;
 
-const QUIZ_QUERY = /* groq */ `
-*[_type == "quiz" && (
-  slug.current in $slugCandidates ||
-  lower(slug.current) in $lowerSlugCandidates ||
-  _id in $slugCandidates
-)][0]{
+const QUIZ_BY_SLUG_QUERY = /* groq */ `
+*[_type == "quiz" && slug.current == $slug && !(_id in path("drafts.**"))][0]{
   _id,
   _createdAt,
   _updatedAt,
@@ -66,6 +62,16 @@ export const entries = async () => {
   }
 };
 
+const fetchQuizBySlug = async (slug) => {
+  if (!slug) return null;
+  try {
+    return await client.fetch(QUIZ_BY_SLUG_QUERY, { slug });
+  } catch (err) {
+    console.error(`[quiz slug:${slug}] Failed to fetch quiz by slug`, err);
+    return null;
+  }
+};
+
 const resolveSlugFromCatalog = async (slugCandidates, lowerSlugCandidates) => {
   try {
     const catalog = await client.fetch(QUIZ_SLUGS_QUERY);
@@ -78,14 +84,19 @@ const resolveSlugFromCatalog = async (slugCandidates, lowerSlugCandidates) => {
 
     for (const entry of catalog) {
       const candidateSlug = entry?.slug;
-      if (!candidateSlug) continue;
-      const { candidates: entryCandidates, lowerCandidates: entryLowerCandidates } = createSlugQueryPayload(
-        candidateSlug
-      );
+      const candidateId = entry?._id;
+      if (candidateId && slugCandidateSet.has(candidateId)) {
+        return candidateSlug ?? null;
+      }
+
+      if (typeof candidateSlug !== 'string' || candidateSlug.length === 0) continue;
+
+      const { candidates: entryCandidates, lowerCandidates: entryLowerCandidates } =
+        createSlugQueryPayload(candidateSlug);
       const hasDirectOverlap = entryCandidates.some((value) => slugCandidateSet.has(value));
       const hasLowerOverlap = entryLowerCandidates.some((value) => lowerCandidateSet.has(value));
       if (hasDirectOverlap || hasLowerOverlap) {
-        return { slug: candidateSlug, id: entry?._id };
+        return candidateSlug;
       }
     }
   } catch (fallbackError) {
@@ -157,30 +168,12 @@ export const load = async (event) => {
   }
 
   try {
-    let doc = await client.fetch(QUIZ_QUERY, {
-      slugCandidates,
-      lowerSlugCandidates
-    });
+    let doc = await fetchQuizBySlug(primarySlug);
 
     if (!doc) {
-      const resolved = await resolveSlugFromCatalog(slugCandidates, lowerSlugCandidates);
-      if (resolved?.slug) {
-        const resolvedPayload = createSlugQueryPayload(resolved.slug);
-        const nextSlugCandidates = mergeSlugCandidateLists(
-          slugCandidates,
-          resolvedPayload.candidates,
-          [resolved.slug],
-          resolved?.id ? [resolved.id] : []
-        );
-        const nextLowerCandidates = mergeSlugCandidateLists(
-          lowerSlugCandidates,
-          resolvedPayload.lowerCandidates
-        );
-
-        doc = await client.fetch(QUIZ_QUERY, {
-          slugCandidates: nextSlugCandidates,
-          lowerSlugCandidates: nextLowerCandidates
-        });
+      const resolvedSlug = await resolveSlugFromCatalog(slugCandidates, lowerSlugCandidates);
+      if (resolvedSlug && resolvedSlug !== primarySlug) {
+        doc = await fetchQuizBySlug(resolvedSlug);
       }
     }
 

--- a/src/routes/quiz/matchstick/article/[id]/+page.server.js
+++ b/src/routes/quiz/matchstick/article/[id]/+page.server.js
@@ -8,11 +8,11 @@ import { createPageSeo, portableTextToPlain } from '$lib/seo.js';
 export const prerender = false;
 
 const QUIZ_IDS_QUERY = /* groq */ `
-*[_type == "quiz" && defined(_id)]{ _id }
+*[_type == "quiz" && defined(_id) && !(_id in path("drafts.**"))]{ _id }
 `;
 
 const Q = /* groq */ `
-*[_type == "quiz" && _id == $id][0]{
+*[_type == "quiz" && _id == $id && !(_id in path("drafts.**"))][0]{
   _id,
   title,
   "slug": slug.current,

--- a/src/routes/quiz/spot-the-difference/article/[id]/+page.server.js
+++ b/src/routes/quiz/spot-the-difference/article/[id]/+page.server.js
@@ -8,11 +8,11 @@ import { createPageSeo, portableTextToPlain } from '$lib/seo.js';
 export const prerender = false;
 
 const QUIZ_IDS_QUERY = /* groq */ `
-*[_type == "quiz" && defined(_id)]{ _id }
+*[_type == "quiz" && defined(_id) && !(_id in path("drafts.**"))]{ _id }
 `;
 
 const Q = /* groq */ `
-*[_type == "quiz" && _id == $id][0]{
+*[_type == "quiz" && _id == $id && !(_id in path("drafts.**"))][0]{
   _id,
   title,
   "slug": slug.current,

--- a/src/routes/sitemap.xml/+server.js
+++ b/src/routes/sitemap.xml/+server.js
@@ -10,11 +10,11 @@ const STATIC_ROUTES = [
 ];
 
 const QUERY = /* groq */ `{
-  "categories": *[_type == "category" && defined(slug.current)] | order(_updatedAt desc) {
+  "categories": *[_type == "category" && defined(slug.current) && !(_id in path("drafts.**"))] | order(_updatedAt desc) {
     "slug": slug.current,
     _updatedAt
   },
-  "quizzes": *[_type == "quiz" && defined(slug.current)] | order(_updatedAt desc) {
+  "quizzes": *[_type == "quiz" && defined(slug.current) && !(_id in path("drafts.**"))] | order(_updatedAt desc) {
     "slug": slug.current,
     _updatedAt,
     _createdAt,


### PR DESCRIPTION
## Summary
- include quiz document ids when building the slug catalog used for fallback resolution
- fall back from legacy id-based URLs to the published slug before fetching quiz and answer data

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68da2a94f06c832f980b85954f05d40c