### PR TITLE
Ensure quiz fallback returns 200 for missing Sanity docs

### DIFF
--- a/src/routes/quiz/[slug]/+page.server.js
+++ b/src/routes/quiz/[slug]/+page.server.js
@@ -1,4 +1,3 @@
-import { error } from '@sveltejs/kit';
 import { urlFor, shouldSkipSanityFetch, sanityEnv } from '$lib/sanity.server.js';
 import { SITE } from '$lib/config/site.js';
 import { createPageSeo, portableTextToPlain } from '$lib/seo.js';
@@ -84,7 +83,13 @@ export const load = async (event) => {
 
     if (!doc) {
       console.warn('[quiz/[slug]] 0件', { slugCandidates });
-      throw error(404, 'Not found');
+      const fallbackResponse = buildFallback(primarySlug, url.pathname);
+      console.info('[quiz/[slug]] FALLBACK response', {
+        slug: primarySlug,
+        dataSource: fallbackResponse.__dataSource,
+        status: 200
+      });
+      return fallbackResponse;
     }
 
     if (resolvedSlug && resolvedSlug !== primarySlug) {
@@ -147,6 +152,12 @@ export const load = async (event) => {
       throw err;
     }
     console.error(`[quiz/${rawSlug}] ERR`, err);
-    return buildFallback(primarySlug, url.pathname);
+    const fallbackResponse = buildFallback(primarySlug, url.pathname);
+    console.info('[quiz/[slug]] FALLBACK response (error)', {
+      slug: primarySlug,
+      dataSource: fallbackResponse.__dataSource,
+      status: 200
+    });
+    return fallbackResponse;
   }
 };

--- a/src/routes/quiz/[slug]/answer/+page.server.js
+++ b/src/routes/quiz/[slug]/answer/+page.server.js
@@ -1,4 +1,3 @@
-import { error } from '@sveltejs/kit';
 import { urlFor, shouldSkipSanityFetch, sanityEnv } from '$lib/sanity.server.js';
 import { SITE } from '$lib/config/site.js';
 import { createPageSeo, portableTextToPlain } from '$lib/seo.js';
@@ -86,7 +85,13 @@ export const load = async (event) => {
 
     if (!doc) {
       console.warn('[quiz/[slug]/answer] 0件', { slugCandidates });
-      throw error(404, 'Not found');
+      const fallbackResponse = buildFallback(primarySlug, url.pathname);
+      console.info('[quiz/[slug]/answer] FALLBACK response', {
+        slug: primarySlug,
+        dataSource: fallbackResponse.__dataSource,
+        status: 200
+      });
+      return fallbackResponse;
     }
 
     if (resolvedSlug && resolvedSlug !== primarySlug) {
@@ -145,6 +150,12 @@ export const load = async (event) => {
       throw err;
     }
     console.error(`[quiz/${rawSlug}/answer] ERR`, err);
-    return buildFallback(primarySlug, url.pathname);
+    const fallbackResponse = buildFallback(primarySlug, url.pathname);
+    console.info('[quiz/[slug]/answer] FALLBACK response (error)', {
+      slug: primarySlug,
+      dataSource: fallbackResponse.__dataSource,
+      status: 200
+    });
+    return fallbackResponse;
   }
 };


### PR DESCRIPTION
## Summary
- stop throwing 404 when quiz detail or answer documents are missing from Sanity
- return the prebuilt fallback payload and log that a 200 fallback response was served
- log fallback metadata when an unexpected error occurs while fetching Sanity data

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68db299e6d5c832fa0fbd6a8f2eb471e