### PR TITLE
UI フラグと canonical 出力の微修正

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,14 +3,17 @@
   import { page } from '$app/stores';
   import { SITE } from '$lib/config/site.js';
   import { createPageSeo } from '$lib/seo.js';
+  import Breadcrumbs from '$lib/components/Breadcrumbs.svelte';
 
   export let data;
 
   const twitterHandle = SITE.twitterHandle ?? '';
 
   $: currentPage = $page;
-  $: uiSettings = currentPage?.data?.ui ?? {};
-  $: hideGlobalNav = Boolean(uiSettings.hideGlobalNav);
+  $: ui = currentPage?.data?.ui ?? {};
+  $: breadcrumbs = Array.isArray(currentPage?.data?.breadcrumbs)
+    ? currentPage.data.breadcrumbs
+    : [];
   $: fallbackSeo = createPageSeo({
     path: currentPage?.url?.pathname ?? '/',
     appendSiteName: false
@@ -98,7 +101,7 @@
   {/each}
 </svelte:head>
 
-{#if !hideGlobalNav}
+{#if ui.showHeader !== false}
   <header class="site-header">
     <div class="header-content">
       <a href="/" class="logo-section" aria-label="脳トレ日和 トップページ">
@@ -118,7 +121,9 @@
       </a>
     </div>
   </header>
+{/if}
 
+{#if !ui.hideGlobalNavTabs}
   <nav class="main-nav global-nav">
     <div class="nav-container">
       <ul class="nav-menu">
@@ -132,6 +137,12 @@
       </ul>
     </div>
   </nav>
+{/if}
+
+{#if !ui.hideBreadcrumbs && breadcrumbs.length}
+  <div class="breadcrumbs-container">
+    <Breadcrumbs items={breadcrumbs} />
+  </div>
 {/if}
 
 <main>
@@ -193,6 +204,12 @@
     display: flex;
     align-items: center;
     justify-content: center;
+  }
+
+  .breadcrumbs-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 0 1rem;
   }
 
   @media (max-width: 768px) {

--- a/src/routes/quiz/[...slug]/answer/+page.server.js
+++ b/src/routes/quiz/[...slug]/answer/+page.server.js
@@ -1,5 +1,4 @@
 import { error, redirect } from '@sveltejs/kit';
-import { SITE } from '$lib/config/site.js';
 import { createSlugContext, findQuizDocument } from '$lib/server/quiz.js';
 
 export const prerender = false;
@@ -15,15 +14,6 @@ const Q = /* groq */ `*[_type == "quiz" && slug.current == $slug && !(_id in pat
   answerExplanation,
   closingMessage
 }`;
-
-const toCanonicalUrl = (slug, suffix = '') => {
-  try {
-    return new URL(`/quiz/${slug}${suffix}`, SITE.url).href;
-  } catch (error) {
-    console.error('[quiz/[...slug]/answer] Failed to build canonical URL', error);
-    return `/quiz/${slug}${suffix}`;
-  }
-};
 
 export async function load({ params, setHeaders }) {
   const slugSegments = Array.isArray(params.slug) ? params.slug : [params.slug];
@@ -41,7 +31,13 @@ export async function load({ params, setHeaders }) {
   setHeaders({ 'Cache-Control': 'public, max-age=60, s-maxage=300' });
   return {
     quiz,
-    ui: { hideGlobalNav: true, hideBreadcrumbs: true },
-    canonicalPath: toCanonicalUrl(quiz.slug, '/answer')
+    ui: {
+      showHeader: true,
+      hideGlobalNavTabs: true,
+      hideBreadcrumbs: true
+    },
+    seo: {
+      canonical: `/quiz/${quiz.slug}/answer`
+    }
   };
 }

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -63,10 +63,6 @@
   const questionPath = `/quiz/${quiz?.slug ?? ''}`;
 </script>
 
-<svelte:head>
-  <link rel="canonical" href={data.canonicalPath} />
-</svelte:head>
-
 <main class="answer-page hide-chrome">
   <header class="quiz-header">
     <h1 class="quiz-title">{quiz.title}｜正解</h1>
@@ -85,21 +81,16 @@
     </section>
   {/if}
 
-  <nav class="back-nav">
+  <nav class="back-nav" style="text-align:center">
     <a class="btn" href={questionPath}>問題ページに戻る</a>
   </nav>
 
   <footer class="closing">
-    <p>{closingText}</p>
+    <p>{closingText || closingDefault}</p>
   </footer>
 </main>
 
 <style>
-  :global(.global-nav),
-  :global(.breadcrumbs) {
-    display: none !important;
-  }
-
   .answer-page {
     max-width: 820px;
     margin: 40px auto;


### PR DESCRIPTION
## 概要
- ルートレイアウトで ui フラグの判定を showHeader/hideGlobalNavTabs/hideBreadcrumbs に一本化
- クイズ詳細/正解ページの load で canonical を seo に渡し、ページ内の重複 link を削除

## テスト
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68dbe23b9e78832fae457ecf19637dde