### PR TITLE
feat: クイズ記事ページのUI刷新

### DIFF
--- a/src/routes/quiz/[...slug]/+page.svelte
+++ b/src/routes/quiz/[...slug]/+page.svelte
@@ -100,7 +100,9 @@
 
 <main class="quiz-detail hide-chrome">
   <header class="quiz-header">
+    <p class="quiz-meta" aria-hidden="true">今日の脳トレ</p>
     <h1 class="quiz-title">{doc.title}</h1>
+    <p class="quiz-subtitle">ひらめきスイッチを入れて、ゆったり挑戦しましょう。</p>
   </header>
 
   {#if doc.problemImage?.asset?.url}
@@ -110,28 +112,36 @@
   {/if}
 
   {#if bodyHtml}
-    <section class="body">
-      <div>{@html bodyHtml}</div>
+    <section class="body content-card">
+      <div class="section-header">
+        <span class="section-icon" aria-hidden="true">🧠</span>
+        <h2>問題</h2>
+      </div>
+      <div class="section-body">{@html bodyHtml}</div>
     </section>
   {/if}
 
   {#if hints.length}
-    <div class="hints-toggle" style="text-align: center; margin: 24px 0;">
+    <div class="hints-toggle">
       <button
         type="button"
-        class="btn"
+        class="action-button hint-button"
         aria-expanded={hintOpen}
         aria-controls={hintsId}
         on:click={toggleHints}
       >
+        <span aria-hidden="true">💡</span>
         {hintOpen ? 'ヒントを隠す' : `ヒントを見る（${hints.length}件）`}
       </button>
     </div>
 
     {#if hintOpen}
-      <section class="hints" id={hintsId} style="margin: 16px 0;">
-        <h2 style="font-size: 18px; margin: 0 0 8px;">ヒント</h2>
-        <ul style="padding-left: 1.2em;">
+      <section class="hints content-card" id={hintsId}>
+        <div class="section-header">
+          <span class="section-icon" aria-hidden="true">✨</span>
+          <h2>ヒント</h2>
+        </div>
+        <ul>
           {#if firstHint}
             <li tabindex="-1" bind:this={firstHintItem}>{firstHint.text}</li>
           {/if}
@@ -144,76 +154,227 @@
   {/if}
 
   <nav class="to-answer">
-    <a class="btn" href={answerPath}>正解ページへ進む →</a>
+    <a class="action-button primary" href={answerPath}>
+      正解ページへ進む
+      <span class="sr-only">次のページへ</span>
+      <span aria-hidden="true">→</span>
+    </a>
   </nav>
 </main>
 
 <style>
   .quiz-detail {
     max-width: 820px;
-    margin: 40px auto;
-    padding: 0 16px;
+    margin: 24px auto 56px;
+    padding: 0 16px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .quiz-header {
+    text-align: center;
+    background: linear-gradient(135deg, rgba(255, 241, 204, 0.7), rgba(255, 255, 255, 0.9));
+    border-radius: 24px;
+    padding: 28px 24px 32px;
+    box-shadow: 0 18px 45px rgba(255, 193, 7, 0.18);
+    border: 1px solid rgba(250, 204, 21, 0.35);
+    backdrop-filter: blur(4px);
+  }
+
+  .quiz-meta {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    color: #b45309;
+    font-weight: 700;
+    margin-bottom: 8px;
   }
 
   .quiz-title {
-    font-size: 24px;
+    font-size: clamp(1.8rem, 4vw, 2.4rem);
     line-height: 1.4;
-    margin: 0 0 12px;
-    text-align: center;
+    margin-bottom: 12px;
+    color: #78350f;
+    font-weight: 800;
+  }
+
+  .quiz-subtitle {
+    font-size: 1rem;
+    color: #92400e;
+    opacity: 0.9;
   }
 
   .problem-image {
-    margin: 24px 0;
+    margin: 0 auto;
     text-align: center;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(255, 249, 232, 0.9));
+    padding: 18px;
+    border-radius: 24px;
+    box-shadow: 0 12px 32px rgba(251, 191, 36, 0.22);
+    border: 1px solid rgba(253, 224, 71, 0.45);
   }
 
   .problem-image img {
     max-width: 100%;
     height: auto;
-    border-radius: 8px;
+    border-radius: 18px;
+    box-shadow: 0 10px 25px rgba(249, 115, 22, 0.16);
   }
 
-  .body {
-    margin: 24px 0;
-    line-height: 1.8;
+  .content-card {
+    background: var(--white);
+    border-radius: 24px;
+    padding: 28px 24px;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(248, 196, 113, 0.32);
   }
 
-  .hints {
-    margin: 24px 0;
-    padding: 16px;
-    background: #fff8e1;
-    border-radius: 12px;
-    border: 1px solid #ffe082;
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
   }
 
-  .hints h2 {
-    margin: 0 0 8px;
-    font-size: 18px;
+  .section-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(254, 240, 138, 0.8), rgba(255, 230, 179, 0.95));
+    font-size: 1.3rem;
+    box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.6), 0 8px 14px rgba(249, 115, 22, 0.18);
+  }
+
+  .section-header h2 {
+    font-size: 1.25rem;
+    color: #92400e;
+    font-weight: 700;
+  }
+
+  .section-body :global(p) {
+    margin-bottom: 1em;
+    line-height: 1.85;
+    font-size: 1.05rem;
+  }
+
+  .section-body :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .hints-toggle {
+    text-align: center;
+  }
+
+  .action-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.85rem 2.4rem;
+    border-radius: 999px;
+    border: none;
+    text-decoration: none;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    font-size: 1.05rem;
+    background: linear-gradient(135deg, #facc15, #f97316);
+    color: #78350f;
+    box-shadow: 0 18px 32px rgba(249, 115, 22, 0.28);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  }
+
+  .action-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 36px rgba(234, 88, 12, 0.32);
+    filter: brightness(1.03);
+  }
+
+  .action-button:active {
+    transform: translateY(0);
+    box-shadow: 0 12px 24px rgba(234, 88, 12, 0.24);
+  }
+
+  .action-button span[aria-hidden='true'] {
+    font-size: 1.2rem;
+  }
+
+  .primary {
+    background: linear-gradient(135deg, #facc15, #f97316);
+    color: #78350f;
+  }
+
+  .hint-button {
+    background: linear-gradient(135deg, #fde68a, #fcd34d);
+    color: #92400e;
+    padding-inline: 2rem;
+    box-shadow: 0 16px 28px rgba(250, 204, 21, 0.26);
+  }
+
+  .hint-button:hover {
+    box-shadow: 0 20px 32px rgba(234, 179, 8, 0.3);
   }
 
   .hints ul {
     margin: 0;
     padding-left: 1.2em;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    font-size: 1.05rem;
+    line-height: 1.7;
   }
 
   .hints li {
-    margin-bottom: 6px;
-    line-height: 1.6;
+    position: relative;
+    padding-left: 0.4em;
+  }
+
+  .hints li::marker {
+    color: #f59e0b;
+    font-size: 1.2em;
   }
 
   .to-answer {
-    margin: 28px 0;
     text-align: center;
   }
 
-  .btn {
-    display: inline-block;
-    padding: 10px 20px;
-    border-radius: 999px;
-    border: 1px solid #ddd;
-    text-decoration: none;
-    font-weight: 600;
-    background: #fff;
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (max-width: 640px) {
+    .quiz-detail {
+      margin-top: 16px;
+      gap: 20px;
+    }
+
+    .quiz-header {
+      padding: 24px 18px 28px;
+    }
+
+    .content-card {
+      padding: 24px 18px;
+    }
+
+    .action-button {
+      width: 100%;
+      padding-inline: 1.8rem;
+    }
+
+    .section-header {
+      gap: 10px;
+    }
   }
 
 </style>

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -65,7 +65,9 @@
 
 <main class="answer-page hide-chrome">
   <header class="quiz-header">
+    <p class="quiz-meta" aria-hidden="true">答え合わせ</p>
     <h1 class="quiz-title">{quiz.title}｜正解</h1>
+    <p class="quiz-subtitle">なぜそうなるかを知ると、次の挑戦がもっと楽しくなります。</p>
   </header>
 
   {#if quiz.answerImage?.asset?.url}
@@ -75,76 +77,213 @@
   {/if}
 
   {#if answerHtml}
-    <section class="answer-explanation">
-      <h2>解説</h2>
-      <div>{@html answerHtml}</div>
+    <section class="answer-explanation content-card">
+      <div class="section-header">
+        <span class="section-icon" aria-hidden="true">📝</span>
+        <h2>解説</h2>
+      </div>
+      <div class="section-body">{@html answerHtml}</div>
     </section>
   {/if}
 
-  <nav class="back-nav" style="text-align:center">
-    <a class="btn" href={questionPath}>問題ページに戻る</a>
+  <nav class="back-nav">
+    <a class="action-button secondary" href={questionPath}>
+      <span aria-hidden="true">←</span>
+      問題ページに戻る
+    </a>
   </nav>
 
   <footer class="closing">
-    <p>{closingText || closingDefault}</p>
+    <div class="closing-card">
+      <span class="closing-icon" aria-hidden="true">🌟</span>
+      <p>{closingText || closingDefault}</p>
+    </div>
   </footer>
 </main>
 
 <style>
   .answer-page {
     max-width: 820px;
-    margin: 40px auto;
-    padding: 0 16px;
+    margin: 24px auto 56px;
+    padding: 0 16px 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 24px;
+  }
+
+  .quiz-header {
+    text-align: center;
+    background: linear-gradient(135deg, rgba(255, 237, 213, 0.72), rgba(255, 255, 255, 0.94));
+    border-radius: 24px;
+    padding: 28px 24px 32px;
+    box-shadow: 0 18px 45px rgba(251, 146, 60, 0.18);
+    border: 1px solid rgba(253, 186, 116, 0.35);
+    backdrop-filter: blur(4px);
+  }
+
+  .quiz-meta {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    color: #9a3412;
+    font-weight: 700;
+    margin-bottom: 8px;
   }
 
   .quiz-title {
-    font-size: 24px;
+    font-size: clamp(1.7rem, 3.8vw, 2.35rem);
     line-height: 1.4;
-    margin: 0 0 12px;
-    text-align: center;
+    margin-bottom: 12px;
+    color: #7c2d12;
+    font-weight: 800;
+  }
+
+  .quiz-subtitle {
+    font-size: 1rem;
+    color: #9a3412;
+    opacity: 0.9;
   }
 
   .answer-image {
-    margin: 24px 0;
+    margin: 0 auto;
     text-align: center;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.7), rgba(255, 247, 237, 0.92));
+    padding: 18px;
+    border-radius: 24px;
+    box-shadow: 0 12px 32px rgba(251, 191, 36, 0.18);
+    border: 1px solid rgba(254, 215, 170, 0.45);
   }
 
   .answer-image img {
     max-width: 100%;
     height: auto;
-    border-radius: 8px;
+    border-radius: 18px;
+    box-shadow: 0 10px 25px rgba(248, 113, 113, 0.16);
   }
 
-  .answer-explanation {
-    margin: 24px 0;
-    line-height: 1.8;
+  .content-card {
+    background: var(--white);
+    border-radius: 24px;
+    padding: 28px 24px;
+    box-shadow: 0 18px 45px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(248, 196, 113, 0.28);
   }
 
-  .answer-explanation h2 {
-    margin: 0 0 12px;
-    font-size: 20px;
-    text-align: center;
+  .section-header {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin-bottom: 16px;
+  }
+
+  .section-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 42px;
+    height: 42px;
+    border-radius: 14px;
+    background: linear-gradient(135deg, rgba(254, 205, 211, 0.85), rgba(254, 226, 226, 0.95));
+    font-size: 1.3rem;
+    box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.65), 0 8px 14px rgba(248, 113, 113, 0.22);
+  }
+
+  .section-header h2 {
+    font-size: 1.25rem;
+    color: #b91c1c;
+    font-weight: 700;
+  }
+
+  .section-body :global(p) {
+    margin-bottom: 1em;
+    line-height: 1.85;
+    font-size: 1.05rem;
+  }
+
+  .section-body :global(p:last-child) {
+    margin-bottom: 0;
+  }
+
+  .action-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.6rem;
+    padding: 0.85rem 2.4rem;
+    border-radius: 999px;
+    border: none;
+    text-decoration: none;
+    font-weight: 700;
+    letter-spacing: 0.02em;
+    font-size: 1.05rem;
+    background: linear-gradient(135deg, #facc15, #f97316);
+    color: #78350f;
+    box-shadow: 0 18px 32px rgba(249, 115, 22, 0.28);
+    transition: transform 0.2s ease, box-shadow 0.2s ease, filter 0.2s ease;
+  }
+
+  .action-button:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 22px 36px rgba(234, 88, 12, 0.32);
+    filter: brightness(1.03);
+  }
+
+  .action-button:active {
+    transform: translateY(0);
+    box-shadow: 0 12px 24px rgba(234, 88, 12, 0.24);
+  }
+
+  .secondary {
+    background: linear-gradient(135deg, #fde68a, #fbbf24);
+    color: #92400e;
+    box-shadow: 0 16px 28px rgba(250, 204, 21, 0.26);
   }
 
   .back-nav {
-    margin: 28px 0;
     text-align: center;
-  }
-
-  .btn {
-    display: inline-block;
-    padding: 10px 20px;
-    border-radius: 999px;
-    border: 1px solid #ddd;
-    text-decoration: none;
-    font-weight: 600;
-    background: #fff;
   }
 
   .closing {
-    margin: 32px 0;
+    margin: 0;
+  }
+
+  .closing-card {
+    margin: 0 auto;
+    max-width: 640px;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.88), rgba(255, 248, 227, 0.94));
+    border-radius: 22px;
+    padding: 24px 22px;
     text-align: center;
-    opacity: 0.9;
+    box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
+    border: 1px solid rgba(254, 215, 170, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    color: #92400e;
+    line-height: 1.8;
     white-space: pre-line;
+  }
+
+  .closing-icon {
+    font-size: 1.6rem;
+  }
+
+  @media (max-width: 640px) {
+    .answer-page {
+      margin-top: 16px;
+      gap: 20px;
+    }
+
+    .quiz-header {
+      padding: 24px 18px 28px;
+    }
+
+    .content-card {
+      padding: 24px 18px;
+    }
+
+    .action-button {
+      width: 100%;
+      padding-inline: 1.8rem;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- クイズ問題ページのヘッダーやコンテンツカードを刷新し、余白とヒント表示を今風に整備
- アクションボタンのデザインを統一し、可読性・操作性を向上
- 正解ページの解説ボックスとクロージングメッセージをカード化し、全体の統一感を付与

## Testing
- pnpm test *(Vite開発サーバーの終了コードにより失敗と判定されましたが、テストケース自体は成功しました)*

------
https://chatgpt.com/codex/tasks/task_e_68de3b4aaeb8832f8a9b9fe051261228