### PR TITLE
Fix quiz category reference handling

### DIFF
--- a/src/lib/fetchQuizzes.js
+++ b/src/lib/fetchQuizzes.js
@@ -51,9 +51,9 @@ export async function fetchQuizBySlug(slug) {
   }
 }
 
-export async function fetchQuizzesByCategory(category) {
+export async function fetchQuizzesByCategory(categorySlug) {
   const query = /* groq */ `
-    *[_type == "quiz" && !(_id in path("drafts.**")) && ((defined(category._ref) && category->title == $category) || (!defined(category._ref) && category == $category))] | order(_createdAt desc) {
+    *[_type == "quiz" && !(_id in path("drafts.**")) && defined(category._ref) && category->slug.current == $slug] | order(_createdAt desc) {
       _id,
       title,
       "slug": slug.current,
@@ -63,9 +63,9 @@ export async function fetchQuizzesByCategory(category) {
       _createdAt
     }
   `;
-  
+
   try {
-    const quizzes = await client.fetch(query, { category });
+    const quizzes = await client.fetch(query, { slug: categorySlug });
     return quizzes || [];
   } catch (error) {
     console.error('Error fetching quizzes by category:', error);

--- a/src/routes/quiz/[...slug]/+page.svelte
+++ b/src/routes/quiz/[...slug]/+page.svelte
@@ -114,10 +114,7 @@
   {#if bodyHtml}
     <section class="body content-card">
       <div class="section-header">
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
         <span class="section-icon" aria-hidden="true">🧠</span>
-main
         <h2>問題</h2>
       </div>
       <div class="section-body">{@html bodyHtml}</div>
@@ -141,10 +138,7 @@ main
     {#if hintOpen}
       <section class="hints content-card" id={hintsId}>
         <div class="section-header">
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
           <span class="section-icon" aria-hidden="true">✨</span>
-main
           <h2>ヒント</h2>
         </div>
         <ul>
@@ -236,11 +230,6 @@ main
   }
 
   .section-header {
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-    margin-bottom: 16px;
-  }
-
-
     display: flex;
     align-items: center;
     gap: 12px;
@@ -259,31 +248,20 @@ codex/improve-ui/ux-for-quiz-article-page-r8p1dm
     box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.6), 0 8px 14px rgba(249, 115, 22, 0.18);
   }
 
-main
   .section-header h2 {
     font-size: 1.25rem;
     color: #92400e;
     font-weight: 700;
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
     margin: 0;
   }
 
-  :global(.section-body p) {
-
-  }
-
   .section-body :global(p) {
-main
     margin-bottom: 1em;
     line-height: 1.85;
     font-size: 1.05rem;
   }
 
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-  :global(.section-body p:last-child) {
-
   .section-body :global(p:last-child) {
-main
     margin-bottom: 0;
   }
 
@@ -318,7 +296,6 @@ main
   .action-button:active {
     transform: translateY(0);
     box-shadow: 0 12px 24px rgba(234, 88, 12, 0.24);
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
   }
 
   .action-button span[aria-hidden='true'] {
@@ -337,26 +314,6 @@ codex/improve-ui/ux-for-quiz-article-page-r8p1dm
     box-shadow: 0 16px 28px rgba(250, 204, 21, 0.26);
   }
 
-
-  }
-
-  .action-button span[aria-hidden='true'] {
-    font-size: 1.2rem;
-  }
-
-  .primary {
-    background: linear-gradient(135deg, #facc15, #f97316);
-    color: #78350f;
-  }
-
-  .hint-button {
-    background: linear-gradient(135deg, #fde68a, #fcd34d);
-    color: #92400e;
-    padding-inline: 2rem;
-    box-shadow: 0 16px 28px rgba(250, 204, 21, 0.26);
-  }
-
-main
   .hint-button:hover {
     box-shadow: 0 20px 32px rgba(234, 179, 8, 0.3);
   }
@@ -364,12 +321,9 @@ main
   .hints ul {
     margin: 0;
     padding-left: 1.2em;
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-main
     font-size: 1.05rem;
     line-height: 1.7;
   }
@@ -379,13 +333,10 @@ main
     padding-left: 0.4em;
   }
 
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
   .hints li + li {
     margin-top: 0.75rem;
   }
 
-
-main
   .hints li::marker {
     color: #f59e0b;
     font-size: 1.2em;
@@ -426,12 +377,9 @@ main
       padding-inline: 1.8rem;
     }
 
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
     .section-header {
       gap: 10px;
     }
-main
   }
 
 </style>

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -79,10 +79,7 @@
   {#if answerHtml}
     <section class="answer-explanation content-card">
       <div class="section-header">
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
         <span class="section-icon" aria-hidden="true">📝</span>
-main
         <h2>解説</h2>
       </div>
       <div class="section-body">{@html answerHtml}</div>
@@ -98,10 +95,7 @@ main
 
   <footer class="closing">
     <div class="closing-card">
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
       <span class="closing-icon" aria-hidden="true">🌟</span>
-main
       <p>{closingText || closingDefault}</p>
     </div>
   </footer>
@@ -175,11 +169,6 @@ main
   }
 
   .section-header {
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-    margin-bottom: 16px;
-  }
-
-
     display: flex;
     align-items: center;
     gap: 12px;
@@ -198,31 +187,20 @@ codex/improve-ui/ux-for-quiz-article-page-r8p1dm
     box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.65), 0 8px 14px rgba(248, 113, 113, 0.22);
   }
 
-main
   .section-header h2 {
     font-size: 1.25rem;
     color: #b91c1c;
     font-weight: 700;
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
     margin: 0;
   }
 
-  :global(.section-body p) {
-
-  }
-
   .section-body :global(p) {
-main
     margin-bottom: 1em;
     line-height: 1.85;
     font-size: 1.05rem;
   }
 
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-  :global(.section-body p:last-child) {
-
   .section-body :global(p:last-child) {
-main
     margin-bottom: 0;
   }
 
@@ -278,24 +256,18 @@ main
     text-align: center;
     box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
     border: 1px solid rgba(254, 215, 170, 0.35);
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
     display: flex;
     flex-direction: column;
     gap: 12px;
-main
     color: #92400e;
     line-height: 1.8;
     white-space: pre-line;
   }
 
-codex/improve-ui/ux-for-quiz-article-page-r8p1dm
-
   .closing-icon {
     font-size: 1.6rem;
   }
 
-main
   @media (max-width: 640px) {
     .answer-page {
       margin-top: 16px;

--- a/studio/schemas/index.js
+++ b/studio/schemas/index.js
@@ -2,5 +2,7 @@
 import quiz from './quiz.js'
 import category from './category.js'
 
+export const schemaTypes = [quiz, category]
+
 // Sanity Studio で使うスキーマをまとめて default export
-export default [quiz, category]
+export default schemaTypes


### PR DESCRIPTION
## Summary
- expose schemaTypes export alongside default export for Studio schemas
- simplify category page GROQ query to require a single reference
- update shared quiz fetch helper to filter by referenced category slug

## Testing
- pnpm test *(fails: Expected 200 for /quiz/sample-quiz-a, got 500 due to existing CSS identifier issue in quiz page styles)*

------
https://chatgpt.com/codex/tasks/task_e_68df5e18d490832fb216a5f15e554de2