### PR TITLE
フッター余白調整と固定ページの更新

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -2,8 +2,7 @@
 <html lang="ja">
         <head>
                 <meta charset="utf-8" />
-                <link rel="icon" type="image/svg+xml" sizes="any" href="/logo.svg" />
-                <link rel="apple-touch-icon" href="/logo.svg" />
+                <link rel="icon" type="image/svg+xml" href="/logo.svg" />
                 <meta name="viewport" content="width=device-width, initial-scale=1" />
                 %sveltekit.head%
         </head>

--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -128,7 +128,7 @@ header {
 main {
   max-width: 1200px;
   margin: 0 auto;
-  padding: 1.5rem 1rem 3rem;
+  padding: 1.5rem 1rem 2rem;
 }
 
 button {
@@ -157,7 +157,7 @@ a:focus-visible {
 footer {
   background: var(--dark-gray);
   padding: 2rem 1rem;
-  margin-top: 3rem;
+  margin-top: 0;
   color: var(--white);
 }
 
@@ -168,23 +168,36 @@ footer {
 }
 
 .footer-links {
-  margin-top: 1.5rem;
+  margin: 1.25rem auto 0;
+  padding: 0;
+  list-style: none;
   display: flex;
-  justify-content: center;
-  flex-wrap: wrap;
-  gap: 0.75rem;
+  flex-direction: column;
+  gap: 0.5rem;
+  width: 100%;
+  max-width: 320px;
+}
+
+.footer-links li {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.footer-links li:last-child {
+  border-bottom: none;
 }
 
 .footer-links a {
+  display: block;
+  padding: 0.35rem 0;
   color: rgba(255, 255, 255, 0.85);
   text-decoration: none;
-  padding: 0.5rem 1rem;
-  border-radius: 999px;
-  transition: background 0.2s ease;
+  transition: color 0.2s ease;
 }
 
-.footer-links a:hover {
-  background: rgba(255, 255, 255, 0.1);
+.footer-links a:hover,
+.footer-links a:focus-visible {
+  color: #ffffff;
+  text-decoration: underline;
 }
 
 @media (max-width: 768px) {
@@ -198,7 +211,7 @@ footer {
   }
 
   main {
-    padding: 1.5rem 1rem 2.5rem;
+    padding: 1.5rem 1rem 1.5rem;
   }
 
   .nav-link {
@@ -206,6 +219,6 @@ footer {
   }
 
   footer {
-    margin-top: 2rem;
+    margin-top: 0;
   }
 }

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -152,14 +152,16 @@
 <footer>
   <div class="footer-content">
     <p>&copy; 2025年9月 脳トレ日和 - 毎日の脳トレで健康な生活を</p>
-    <div class="footer-links">
-      <a href="/privacy">プライバシーポリシー</a>
-      <a href="/disclaimer">免責事項</a>
-      <a href="/contact">お問い合わせ</a>
-      <a href="/about">サイトについて</a>
-      <a href="/about#author-info">著者情報</a>
-      <a href="/about#operator-info">運営者情報</a>
-    </div>
+    <nav aria-label="固定ページリンク">
+      <ul class="footer-links">
+        <li><a href="/privacy">プライバシーポリシー</a></li>
+        <li><a href="/disclaimer">免責事項</a></li>
+        <li><a href="/contact">お問い合わせ</a></li>
+        <li><a href="/about">サイトについて</a></li>
+        <li><a href="/about#author-info">著者情報</a></li>
+        <li><a href="/about#operator-info">運営者情報</a></li>
+      </ul>
+    </nav>
   </div>
 </footer>
 

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -12,28 +12,6 @@
     </div>
 
     <div class="about-section">
-      <h3><SectionIcon name="game-icon" className="section-icon" /> 提供ゲーム</h3>
-      <div class="games-grid">
-        <div class="game-info">
-          <h4>記憶力ゲーム</h4>
-          <p>数字の順番を覚える短期記憶のトレーニングゲームです。レベルが上がるにつれて桁数が増加し、段階的に難易度が上がります。</p>
-        </div>
-        <div class="game-info">
-          <h4>計算ゲーム</h4>
-          <p>簡単な足し算、引き算、掛け算の問題に答える計算力向上のゲームです。日常的な計算能力の維持に効果的です。</p>
-        </div>
-        <div class="game-info">
-          <h4>色判別ゲーム</h4>
-          <p>文字の色と内容が一致しているかを判断するゲームです。注意力と判断力を鍛えることができます。</p>
-        </div>
-        <div class="game-info">
-          <h4>文字並べゲーム</h4>
-          <p>バラバラになった文字を正しく並べて単語を完成させるゲームです。語彙力と思考力の向上に役立ちます。</p>
-        </div>
-      </div>
-    </div>
-
-    <div class="about-section">
       <h3><SectionIcon name="features-icon" className="section-icon" /> サイトの特徴</h3>
       <ul class="features-list">
         <li><strong>シンプルな操作</strong> - 誰でも迷わず使える直感的なインターフェース</li>
@@ -182,33 +160,6 @@
     margin-bottom: 1rem;
   }
 
-  .games-grid {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
-    gap: 1.5rem;
-    margin-top: 1.5rem;
-  }
-
-  .game-info {
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 1.5rem;
-    border-radius: 12px;
-    border: 2px solid rgba(255, 235, 59, 0.2);
-  }
-
-  .game-info h4 {
-    font-size: 1.2rem;
-    color: #2d3436;
-    margin-bottom: 0.8rem;
-  }
-
-  .game-info p {
-    color: #636e72;
-    font-size: 0.9rem;
-    line-height: 1.6;
-    margin: 0;
-  }
-
   .features-list, .target-users {
     list-style: none;
     padding: 0;
@@ -300,10 +251,6 @@
 
     .about-section {
       padding: 1.5rem;
-    }
-
-    .games-grid {
-      grid-template-columns: 1fr;
     }
 
     .info-table th, .info-table td {

--- a/src/routes/contact/+page.svelte
+++ b/src/routes/contact/+page.svelte
@@ -55,30 +55,6 @@
       </ul>
     </div>
 
-    <div class="faq-section">
-      <h3><SectionIcon name="text-icon" className="section-icon" /> よくある質問</h3>
-      
-      <div class="faq-item">
-        <h4>Q. ゲームが正常に動作しません</h4>
-        <p>A. ブラウザのキャッシュをクリアしていただくか、別のブラウザでお試しください。それでも解決しない場合は、お使いのデバイスとブラウザの情報を添えてお問い合わせください。</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>Q. スマートフォンでも利用できますか？</h4>
-        <p>A. はい、スマートフォンやタブレットでもご利用いただけます。レスポンシブデザインに対応しており、画面サイズに合わせて最適化されます。</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>Q. 利用料金はかかりますか？</h4>
-        <p>A. 脳トレ日和は完全無料でご利用いただけます。登録も不要です。</p>
-      </div>
-
-      <div class="faq-item">
-        <h4>Q. 新しいゲームの追加予定はありますか？</h4>
-        <p>A. ユーザーの皆様からのご要望を参考に、定期的に新しいゲームの追加を検討しております。ご希望がございましたらお気軽にお聞かせください。</p>
-      </div>
-    </div>
-
     <div class="back-to-home">
       <a href="/" class="back-button">ホームに戻る</a>
     </div>
@@ -191,8 +167,7 @@
     box-shadow: 0 8px 25px rgba(255, 235, 59, 0.4);
   }
 
-  .contact-info,
-  .faq-section {
+  .contact-info {
     background: white;
     padding: 2rem;
     border-radius: 15px;
@@ -200,8 +175,7 @@
     margin-bottom: 2rem;
   }
 
-  .contact-info h3,
-  .faq-section h3 {
+  .contact-info h3 {
     font-size: 1.5rem;
     color: #2d3436;
     margin-bottom: 1rem;
@@ -237,26 +211,6 @@
     font-weight: bold;
   }
 
-  .faq-item {
-    margin-bottom: 1.5rem;
-    padding: 1.5rem;
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    border-radius: 12px;
-    border: 2px solid rgba(255, 235, 59, 0.2);
-  }
-
-  .faq-item h4 {
-    color: #2d3436;
-    margin-bottom: 0.8rem;
-    font-size: 1.1rem;
-  }
-
-  .faq-item p {
-    color: #636e72;
-    line-height: 1.6;
-    margin: 0;
-  }
-
   .back-to-home {
     text-align: center;
   }
@@ -289,8 +243,7 @@
     }
 
     .contact-form-section,
-    .contact-info,
-    .faq-section {
+    .contact-info {
       padding: 1.5rem;
     }
 

--- a/src/routes/quiz/[...slug]/+page.svelte
+++ b/src/routes/quiz/[...slug]/+page.svelte
@@ -114,7 +114,6 @@
   {#if bodyHtml}
     <section class="body content-card">
       <div class="section-header">
-        <span class="section-icon" aria-hidden="true">🧠</span>
         <h2>問題</h2>
       </div>
       <div class="section-body">{@html bodyHtml}</div>
@@ -130,15 +129,13 @@
         aria-controls={hintsId}
         on:click={toggleHints}
       >
-        <span aria-hidden="true">💡</span>
-        {hintOpen ? 'ヒントを隠す' : `ヒントを見る（${hints.length}件）`}
+        {hintOpen ? 'ヒントを隠す' : 'ヒントを見る'}
       </button>
     </div>
 
     {#if hintOpen}
       <section class="hints content-card" id={hintsId}>
         <div class="section-header">
-          <span class="section-icon" aria-hidden="true">✨</span>
           <h2>ヒント</h2>
         </div>
         <ul>
@@ -230,22 +227,7 @@
   }
 
   .section-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
     margin-bottom: 16px;
-  }
-
-  .section-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
-    background: linear-gradient(135deg, rgba(254, 240, 138, 0.8), rgba(255, 230, 179, 0.95));
-    font-size: 1.3rem;
-    box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.6), 0 8px 14px rgba(249, 115, 22, 0.18);
   }
 
   .section-header h2 {
@@ -378,7 +360,7 @@
     }
 
     .section-header {
-      gap: 10px;
+      margin-bottom: 14px;
     }
   }
 

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -79,7 +79,6 @@
   {#if answerHtml}
     <section class="answer-explanation content-card">
       <div class="section-header">
-        <span class="section-icon" aria-hidden="true">📝</span>
         <h2>解説</h2>
       </div>
       <div class="section-body">{@html answerHtml}</div>
@@ -95,7 +94,6 @@
 
   <footer class="closing">
     <div class="closing-card">
-      <span class="closing-icon" aria-hidden="true">🌟</span>
       <p>{closingText || closingDefault}</p>
     </div>
   </footer>
@@ -169,22 +167,7 @@
   }
 
   .section-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
     margin-bottom: 16px;
-  }
-
-  .section-icon {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 42px;
-    height: 42px;
-    border-radius: 14px;
-    background: linear-gradient(135deg, rgba(254, 205, 211, 0.85), rgba(254, 226, 226, 0.95));
-    font-size: 1.3rem;
-    box-shadow: inset 0 2px 6px rgba(255, 255, 255, 0.65), 0 8px 14px rgba(248, 113, 113, 0.22);
   }
 
   .section-header h2 {
@@ -256,16 +239,9 @@
     text-align: center;
     box-shadow: 0 16px 36px rgba(15, 23, 42, 0.08);
     border: 1px solid rgba(254, 215, 170, 0.35);
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
     color: #92400e;
     line-height: 1.8;
     white-space: pre-line;
-  }
-
-  .closing-icon {
-    font-size: 1.6rem;
   }
 
   @media (max-width: 640px) {


### PR DESCRIPTION
## Summary
- フッター直前の余白を縮小し、固定ページリンクを縦並びのリストに変更
- サイトアイコンの重複リンクを解消し、クイズページのセクション見出しから絵文字を除去
- お問い合わせ・脳トレ日和について各固定ページから不要セクションを削除

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68df6fdc5a50832fbe5bd3f7d4287d39