### PR TITLE
Adjust related quiz sections and footer tagline

### DIFF
--- a/src/lib/components/RelatedQuizSection.svelte
+++ b/src/lib/components/RelatedQuizSection.svelte
@@ -1,0 +1,193 @@
+<script>
+  import { createSanityImageSet } from '$lib/utils/images.js';
+
+  export let quizzes = [];
+  export let heading = '関連記事';
+  export let headingId = 'related-heading';
+  export let fallbackImageUrl = '/logo.svg';
+
+  const formatDate = (value) => {
+    if (!value) return '';
+    const date = new Date(value);
+    if (Number.isNaN(date.getTime())) return '';
+    const year = date.getFullYear();
+    const month = date.getMonth() + 1;
+    const day = date.getDate();
+    return `${year}年${month}月${day}日`;
+  };
+
+  const getPreviewImageSet = (quiz) => {
+    const source = quiz?.image ?? quiz?.problemImage ?? quiz?.mainImage ?? null;
+    const fallback = source?.asset?.url ?? fallbackImageUrl;
+    return createSanityImageSet(source ?? fallback, {
+      width: 480,
+      height: 288,
+      quality: 75,
+      fallbackUrl: fallback
+    });
+  };
+
+  const getPreviewDimensions = (quiz) => {
+    const source = quiz?.image ?? quiz?.problemImage ?? quiz?.mainImage;
+    return source?.asset?.metadata?.dimensions ?? { width: 480, height: 288 };
+  };
+
+  $: items = Array.isArray(quizzes) ? quizzes : [];
+  $: hasItems = items.length > 0;
+</script>
+
+{#if hasItems}
+  <section class="related-section" aria-labelledby={headingId}>
+    <div class="related-header">
+      <h2 id={headingId}>{heading}</h2>
+    </div>
+    <div class="related-grid">
+      {#each items as quiz (quiz.slug)}
+        {@const imageSet = getPreviewImageSet(quiz)}
+        {@const dims = getPreviewDimensions(quiz)}
+        <a class="related-card" href={`/quiz/${quiz.slug}`}>
+          {#if imageSet?.src}
+            <picture>
+              {#if imageSet.avifSrcset}
+                <source
+                  srcset={imageSet.avifSrcset}
+                  type="image/avif"
+                  sizes="(min-width: 768px) 360px, 90vw"
+                />
+              {/if}
+              {#if imageSet.webpSrcset}
+                <source
+                  srcset={imageSet.webpSrcset}
+                  type="image/webp"
+                  sizes="(min-width: 768px) 360px, 90vw"
+                />
+              {/if}
+              <img
+                src={imageSet.src}
+                srcset={imageSet.srcset}
+                sizes="(min-width: 768px) 360px, 90vw"
+                alt={`${quiz.title}の問題イメージ`}
+                loading="lazy"
+                decoding="async"
+                width={Math.round(dims.width)}
+                height={Math.round(dims.height)}
+              />
+            </picture>
+          {/if}
+          <div class="related-card-body">
+            <p class="related-card-category">#{quiz?.category?.title ?? '脳トレ'}</p>
+            <h3>{quiz.title}</h3>
+            {#if quiz?.publishedAt || quiz?.createdAt}
+              <p class="related-card-date">{formatDate(quiz.publishedAt ?? quiz.createdAt)}</p>
+            {/if}
+          </div>
+        </a>
+      {/each}
+    </div>
+  </section>
+{/if}
+
+<style>
+  .related-section {
+    background: #fffef6;
+    border-radius: 24px;
+    padding: 28px 24px 32px;
+    box-shadow: 0 18px 45px rgba(249, 115, 22, 0.14);
+    border: 1px solid rgba(248, 196, 113, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 1.75rem;
+  }
+
+  .related-header h2 {
+    margin: 0;
+    font-size: 1.35rem;
+    color: #9a3412;
+    font-weight: 800;
+    text-align: center;
+  }
+
+  .related-grid {
+    display: grid;
+    gap: 1.4rem;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .related-card {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    text-decoration: none;
+    border-radius: 18px;
+    overflow: hidden;
+    background: #ffffff;
+    border: 1px solid rgba(248, 196, 113, 0.35);
+    box-shadow: 0 14px 32px rgba(249, 115, 22, 0.12);
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+  }
+
+  .related-card:hover,
+  .related-card:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 44px rgba(234, 88, 12, 0.22);
+    outline: none;
+  }
+
+  .related-card picture {
+    aspect-ratio: calc(4 / 3);
+    overflow: hidden;
+    display: block;
+    background: #fff7ed;
+  }
+
+  .related-card img {
+    display: block;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+
+  .related-card-body {
+    padding: 0 1.2rem 1.4rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+  }
+
+  .related-card-category {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #b45309;
+    font-weight: 700;
+    letter-spacing: 0.05em;
+  }
+
+  .related-card h3 {
+    margin: 0;
+    font-size: 1.05rem;
+    color: #78350f;
+    line-height: 1.4;
+    font-weight: 700;
+  }
+
+  .related-card-date {
+    margin: 0;
+    font-size: 0.85rem;
+    color: #6b7280;
+  }
+
+  @media (max-width: 768px) {
+    .related-section {
+      padding: 24px 18px 28px;
+      gap: 1.5rem;
+    }
+
+    .related-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .related-card {
+      box-shadow: 0 14px 34px rgba(249, 115, 22, 0.18);
+    }
+  }
+</style>

--- a/src/lib/server/related-quizzes.js
+++ b/src/lib/server/related-quizzes.js
@@ -1,0 +1,98 @@
+import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
+
+const RELATED_QUERY = /* groq */ `{
+  "sameCategory": *[
+    _type == "quiz"
+    && defined(slug.current)
+    && !(_id in path("drafts.**"))
+    && slug.current != $slug
+    && $categorySlug != null
+    && defined(category._ref)
+    && category->slug.current == $categorySlug
+    && (!defined(publishedAt) || publishedAt <= now())
+  ] | order(coalesce(publishedAt, _createdAt) desc)[0...6]{
+    _id,
+    title,
+    "slug": slug.current,
+    category->{ title, "slug": slug.current },
+    mainImage{ asset->{ url, metadata } },
+    problemImage{ asset->{ url, metadata } },
+    publishedAt,
+    _createdAt
+  },
+  "popular": *[
+    _type == "quiz"
+    && defined(slug.current)
+    && !(_id in path("drafts.**"))
+    && (!defined(publishedAt) || publishedAt <= now())
+  ] | order(
+    coalesce(popularityScore, viewCount, totalViews, impressions, 0) desc,
+    coalesce(publishedAt, _createdAt) desc
+  )[0...8]{
+    _id,
+    title,
+    "slug": slug.current,
+    category->{ title, "slug": slug.current },
+    mainImage{ asset->{ url, metadata } },
+    problemImage{ asset->{ url, metadata } },
+    publishedAt,
+    _createdAt
+  }
+}`;
+
+const pickImage = (quiz) =>
+  quiz?.problemImage?.asset?.url
+    ? quiz.problemImage
+    : quiz?.mainImage?.asset?.url
+      ? quiz.mainImage
+      : null;
+
+const toPreview = (quiz) => {
+  if (!quiz?.slug) return null;
+  const image = pickImage(quiz);
+  const publishedAt = quiz?.publishedAt ?? quiz?._createdAt;
+  return {
+    id: quiz._id ?? quiz.slug,
+    title: quiz.title ?? '脳トレ問題',
+    slug: quiz.slug,
+    category: quiz.category ?? null,
+    image,
+    publishedAt,
+    createdAt: quiz?._createdAt
+  };
+};
+
+export async function fetchRelatedQuizzes({ slug, categorySlug }) {
+  if (shouldSkipSanityFetch()) return [];
+
+  try {
+    const payload = await client.fetch(RELATED_QUERY, {
+      slug,
+      categorySlug: categorySlug ?? null
+    });
+    const sameCategory = Array.isArray(payload?.sameCategory)
+      ? payload.sameCategory.map(toPreview).filter(Boolean)
+      : [];
+    const popular = Array.isArray(payload?.popular)
+      ? payload.popular.map(toPreview).filter(Boolean)
+      : [];
+
+    const filteredSameCategory = sameCategory.filter((item) => item.slug !== slug);
+    const filteredPopular = popular.filter((item) => item.slug !== slug);
+
+    const merged = filteredSameCategory.slice(0, 6);
+    const seen = new Set(merged.map((item) => item.slug));
+
+    for (const item of filteredPopular) {
+      if (merged.length >= 6) break;
+      if (seen.has(item.slug)) continue;
+      merged.push(item);
+      seen.add(item.slug);
+    }
+
+    return merged;
+  } catch (error) {
+    console.error('[related-quizzes] failed to fetch related quizzes', error);
+    return [];
+  }
+}

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -12,13 +12,10 @@
   const suggestionLinks = [
     { href: '/', label: 'トップページに戻る', type: 'link' },
     { href: '/quiz', label: 'クイズ一覧を見る', type: 'link' },
-codex/implement-code-improvements-for-adsense-review-3ewrjj
-
     {
       type: 'message',
       message: 'カテゴリページは記事のパンくずからアクセスできます'
     },
-main
     { href: '/contact', label: 'お問い合わせ', type: 'link' }
   ];
 </script>

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -158,14 +158,11 @@
 
 <footer data-review-mode={reviewMode}>
   <div class="footer-content">
-codex/implement-code-improvements-for-adsense-review-3ewrjj
-    <p class="footer-copy">
-      &copy; 2025年9月 脳トレ日和<br />
-      <span class="footer-tagline">毎日の脳トレで健康な生活を</span>
+    <p class="footer-tagline">
+      毎日の脳トレで<br class="footer-tagline-break" />健康な生活を
     </p>
 
     <p class="footer-copy">&copy; 2025年9月 脳トレ日和 - 毎日の脳トレで健康な生活を</p>
-main
     <nav aria-label="固定ページリンク">
       <ul class="footer-links">
         <li><a href="/privacy">プライバシーポリシー</a></li>
@@ -287,16 +284,19 @@ main
     text-align: center;
     color: #4b5563;
     font-size: 0.95rem;
-codex/implement-code-improvements-for-adsense-review-3ewrjj
     line-height: 1.6;
   }
 
   .footer-tagline {
-    display: block;
-    margin-top: 0.25rem;
-
-main
+    margin: 0;
+    text-align: center;
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #b45309;
+    line-height: 1.8;
+    letter-spacing: 0.04em;
   }
+
 
   .footer-links {
     list-style: none;
@@ -349,6 +349,11 @@ main
 
     .footer-content {
       padding: 2rem 1.5rem 2.5rem;
+    }
+
+    .footer-tagline {
+      font-size: 1rem;
+      line-height: 1.7;
     }
   }
 </style>

--- a/src/routes/quiz/[...slug]/+page.svelte
+++ b/src/routes/quiz/[...slug]/+page.svelte
@@ -1,15 +1,11 @@
 <script>
   import { tick } from 'svelte';
   import { createSanityImageSet } from '$lib/utils/images.js';
+  import RelatedQuizSection from '$lib/components/RelatedQuizSection.svelte';
 
   export let data;
   const { doc } = data;
-codex/implement-code-improvements-for-adsense-review-3ewrjj
   const relatedQuizzes = Array.isArray(data?.related) ? data.related : [];
-
-  const sameCategoryQuizzes = Array.isArray(data?.related) ? data.related : [];
-  const popularQuizzes = Array.isArray(data?.popular) ? data.popular : [];
-main
 
   const fallbackQuizImage = doc?.problemImage ?? doc?.mainImage;
   const fallbackImageUrl =
@@ -32,27 +28,7 @@ main
   const category = doc?.category?.title && doc?.category?.slug ? doc.category : null;
   const categoryUrl = category ? `/category/${category.slug}` : null;
 
-  const getPreviewImageSet = (quiz) => {
-    const source = quiz?.image ?? quiz?.problemImage ?? quiz?.mainImage ?? null;
-    const fallback = source?.asset?.url ?? fallbackImageUrl;
-    return createSanityImageSet(source ?? fallback, {
-      width: 480,
-      height: 288,
-      quality: 75,
-      fallbackUrl: fallback
-    });
-  };
-
-  const getPreviewDimensions = (quiz) => {
-    const source = quiz?.image ?? quiz?.problemImage ?? quiz?.mainImage;
-    return source?.asset?.metadata?.dimensions ?? { width: 480, height: 288 };
-  };
-
-codex/implement-code-improvements-for-adsense-review-3ewrjj
   const hasRelated = relatedQuizzes.length > 0;
-
-  const hasRelated = sameCategoryQuizzes.length > 0 || popularQuizzes.length > 0;
-main
 
   const formatDate = (value) => {
     if (!value) return '';
@@ -245,131 +221,7 @@ main
   </nav>
 
   {#if hasRelated}
-    <section class="related content-card" aria-labelledby="related-heading">
-      <div class="section-header">
-        <h2 id="related-heading">関連記事</h2>
-      </div>
-codex/implement-code-improvements-for-adsense-review-3ewrjj
-      <div class="related-grid">
-        {#each relatedQuizzes as quiz (quiz.slug)}
-          {@const imageSet = getPreviewImageSet(quiz)}
-          {@const dims = getPreviewDimensions(quiz)}
-          <a class="related-card" href={`/quiz/${quiz.slug}`}>
-            {#if imageSet?.src}
-              <picture>
-                {#if imageSet.avifSrcset}
-                  <source srcset={imageSet.avifSrcset} type="image/avif" sizes="(min-width: 768px) 300px, 90vw" />
-                {/if}
-                {#if imageSet.webpSrcset}
-                  <source srcset={imageSet.webpSrcset} type="image/webp" sizes="(min-width: 768px) 300px, 90vw" />
-                {/if}
-                <img
-                  src={imageSet.src}
-                  srcset={imageSet.srcset}
-                  sizes="(min-width: 768px) 300px, 90vw"
-                  alt={`${quiz.title}の問題イメージ`}
-                  loading="lazy"
-                  decoding="async"
-                  width={Math.round(dims.width)}
-                  height={Math.round(dims.height)}
-                />
-              </picture>
-            {/if}
-            <div class="related-card-body">
-              <p class="related-card-category">#{quiz?.category?.title ?? '脳トレ'}</p>
-              <h4>{quiz.title}</h4>
-              {#if quiz?.publishedAt || quiz?.createdAt}
-                <p class="related-card-date">{formatDate(quiz.publishedAt ?? quiz.createdAt)}</p>
-              {/if}
-            </div>
-          </a>
-        {/each}
-
-      <div class="related-section-body">
-        {#if sameCategoryQuizzes.length}
-          <div class="related-group">
-            <h3>同じカテゴリの新着</h3>
-            <div class="related-grid">
-              {#each sameCategoryQuizzes as quiz (quiz.slug)}
-                {@const imageSet = getPreviewImageSet(quiz)}
-                {@const dims = getPreviewDimensions(quiz)}
-                <a class="related-card" href={`/quiz/${quiz.slug}`}>
-                  {#if imageSet?.src}
-                    <picture>
-                      {#if imageSet.avifSrcset}
-                        <source srcset={imageSet.avifSrcset} type="image/avif" sizes="(min-width: 768px) 300px, 90vw" />
-                      {/if}
-                      {#if imageSet.webpSrcset}
-                        <source srcset={imageSet.webpSrcset} type="image/webp" sizes="(min-width: 768px) 300px, 90vw" />
-                      {/if}
-                      <img
-                        src={imageSet.src}
-                        srcset={imageSet.srcset}
-                        sizes="(min-width: 768px) 300px, 90vw"
-                        alt={`${quiz.title}の問題イメージ`}
-                        loading="lazy"
-                        decoding="async"
-                        width={Math.round(dims.width)}
-                        height={Math.round(dims.height)}
-                      />
-                    </picture>
-                  {/if}
-                  <div class="related-card-body">
-                    <p class="related-card-category">#{quiz?.category?.title ?? '脳トレ'}</p>
-                    <h4>{quiz.title}</h4>
-                    {#if quiz?.publishedAt || quiz?.createdAt}
-                      <p class="related-card-date">{formatDate(quiz.publishedAt ?? quiz.createdAt)}</p>
-                    {/if}
-                  </div>
-                </a>
-              {/each}
-            </div>
-          </div>
-        {/if}
-
-        {#if popularQuizzes.length}
-          <div class="related-group">
-            <h3>人気の脳トレ</h3>
-            <div class="related-grid popular">
-              {#each popularQuizzes as quiz (quiz.slug)}
-                {@const imageSet = getPreviewImageSet(quiz)}
-                {@const dims = getPreviewDimensions(quiz)}
-                <a class="related-card" href={`/quiz/${quiz.slug}`}>
-                  {#if imageSet?.src}
-                    <picture>
-                      {#if imageSet.avifSrcset}
-                        <source srcset={imageSet.avifSrcset} type="image/avif" sizes="(min-width: 768px) 220px, 90vw" />
-                      {/if}
-                      {#if imageSet.webpSrcset}
-                        <source srcset={imageSet.webpSrcset} type="image/webp" sizes="(min-width: 768px) 220px, 90vw" />
-                      {/if}
-                      <img
-                        src={imageSet.src}
-                        srcset={imageSet.srcset}
-                        sizes="(min-width: 768px) 220px, 90vw"
-                        alt={`${quiz.title}の問題イメージ`}
-                        loading="lazy"
-                        decoding="async"
-                        width={Math.round(dims.width)}
-                        height={Math.round(dims.height)}
-                      />
-                    </picture>
-                  {/if}
-                  <div class="related-card-body">
-                    <p class="related-card-category">#{quiz?.category?.title ?? '脳トレ'}</p>
-                    <h4>{quiz.title}</h4>
-                    {#if quiz?.publishedAt || quiz?.createdAt}
-                      <p class="related-card-date">{formatDate(quiz.publishedAt ?? quiz.createdAt)}</p>
-                    {/if}
-                  </div>
-                </a>
-              {/each}
-            </div>
-          </div>
-        {/if}
-main
-      </div>
-    </section>
+    <RelatedQuizSection quizzes={relatedQuizzes} fallbackImageUrl={fallbackImageUrl} />
   {/if}
 </main>
 
@@ -587,95 +439,6 @@ main
     text-align: center;
   }
 
-codex/implement-code-improvements-for-adsense-review-3ewrjj
-  .related-grid {
-    display: grid;
-    gap: 1.2rem;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-
-  .related-section-body {
-    display: flex;
-    flex-direction: column;
-    gap: 2rem;
-  }
-
-  .related-group h3 {
-    margin: 0 0 1rem;
-    font-size: 1.15rem;
-    color: #92400e;
-  }
-
-  .related-grid {
-    display: grid;
-    gap: 1.2rem;
-    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
-main
-  }
-
-  .related-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.75rem;
-    text-decoration: none;
-    border-radius: 18px;
-    overflow: hidden;
-    background: #fffef6;
-    border: 1px solid rgba(248, 196, 113, 0.35);
-    box-shadow: 0 14px 32px rgba(249, 115, 22, 0.14);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
-  }
-
-  .related-card:hover,
-  .related-card:focus-visible {
-    transform: translateY(-4px);
-    box-shadow: 0 18px 40px rgba(234, 88, 12, 0.24);
-    outline: none;
-  }
-
-  .related-card picture,
-  .related-card img {
-    display: block;
-    width: 100%;
-  }
-
-  .related-card picture {
-    aspect-ratio: calc(4 / 3);
-    overflow: hidden;
-  }
-
-  .related-card img {
-    height: 100%;
-    object-fit: cover;
-  }
-
-  .related-card-body {
-    padding: 0 1.2rem 1.4rem;
-    display: flex;
-    flex-direction: column;
-    gap: 0.4rem;
-  }
-
-  .related-card-category {
-    margin: 0;
-    font-size: 0.85rem;
-    color: #b45309;
-    font-weight: 700;
-    letter-spacing: 0.05em;
-  }
-
-  .related-card h4 {
-    margin: 0;
-    font-size: 1.05rem;
-    color: #78350f;
-    line-height: 1.4;
-  }
-
-  .related-card-date {
-    margin: 0;
-    font-size: 0.85rem;
-    color: #6b7280;
-  }
-
   .sr-only {
     position: absolute;
     width: 1px;
@@ -711,13 +474,6 @@ main
       margin-bottom: 14px;
     }
 
-    .related-grid {
-codex/implement-code-improvements-for-adsense-review-3ewrjj
-      grid-template-columns: minmax(0, 1fr);
-
-      grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
-main
-    }
   }
 </style>
 

--- a/src/routes/quiz/[...slug]/answer/+page.server.js
+++ b/src/routes/quiz/[...slug]/answer/+page.server.js
@@ -1,5 +1,6 @@
 import { error, redirect } from '@sveltejs/kit';
 import { createSlugContext, findQuizDocument } from '$lib/server/quiz.js';
+import { fetchRelatedQuizzes } from '$lib/server/related-quizzes.js';
 
 export const prerender = false;
 export const ssr = true;
@@ -29,8 +30,14 @@ export async function load({ params, setHeaders }) {
     throw redirect(308, `/quiz/${quiz.slug}/answer`);
   }
   setHeaders({ 'Cache-Control': 'public, max-age=60, s-maxage=300' });
+  const related = await fetchRelatedQuizzes({
+    slug: quiz.slug,
+    categorySlug: quiz.category?.slug ?? null
+  });
+
   return {
     quiz,
+    related,
     ui: {
       showHeader: true,
       hideGlobalNavTabs: true,

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -1,6 +1,10 @@
 <script>
+  import RelatedQuizSection from '$lib/components/RelatedQuizSection.svelte';
+
   export let data;
   const { quiz } = data;
+  const relatedQuizzes = Array.isArray(data?.related) ? data.related : [];
+  const relatedFallback = quiz?.answerImage?.asset?.url ?? '/logo.svg';
   const closingDefault =
     'このシリーズは毎日更新。明日も新作を公開します。ブックマークしてまた挑戦してください！';
 
@@ -84,6 +88,12 @@
       <div class="section-body">{@html answerHtml}</div>
     </section>
   {/if}
+
+  <RelatedQuizSection
+    quizzes={relatedQuizzes}
+    fallbackImageUrl={relatedFallback}
+    headingId="related-answer-heading"
+  />
 
   <nav class="back-nav">
     <a class="action-button secondary" href={questionPath}>


### PR DESCRIPTION
## Summary
- break the footer tagline into two lines and refresh its styling for better emphasis
- consolidate article recommendation data and render a six-card related quiz grid through a shared component
- surface the same related quiz section on answer pages by reusing the new server helper

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e4b4182714832fbe075407691f1053