### PR TITLE
Adjust footer copy layout

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -158,11 +158,10 @@
 
 <footer data-review-mode={reviewMode}>
   <div class="footer-content">
-    <p class="footer-tagline">
-      毎日の脳トレで<br class="footer-tagline-break" />健康な生活を
+    <p class="footer-copy">
+      <span class="footer-copy-line">&copy; 2025年9月 脳トレ日和</span>
+      <span class="footer-copy-line">毎日の脳トレで健康な生活を</span>
     </p>
-
-    <p class="footer-copy">&copy; 2025年9月 脳トレ日和 - 毎日の脳トレで健康な生活を</p>
     <nav aria-label="固定ページリンク">
       <ul class="footer-links">
         <li><a href="/privacy">プライバシーポリシー</a></li>
@@ -285,16 +284,13 @@
     color: #4b5563;
     font-size: 0.95rem;
     line-height: 1.6;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
   }
 
-  .footer-tagline {
-    margin: 0;
-    text-align: center;
-    font-size: 1.1rem;
-    font-weight: 700;
-    color: #b45309;
-    line-height: 1.8;
-    letter-spacing: 0.04em;
+  .footer-copy-line {
+    display: block;
   }
 
 
@@ -351,9 +347,5 @@
       padding: 2rem 1.5rem 2.5rem;
     }
 
-    .footer-tagline {
-      font-size: 1rem;
-      line-height: 1.7;
-    }
   }
 </style>

--- a/terms.html
+++ b/terms.html
@@ -105,7 +105,7 @@
 
     <footer>
         <div class="footer-content">
-            <p>&copy; 2025年9月 脳トレ日和 - 毎日の脳トレで健康な生活を</p>
+            <p>&copy; 2025年9月 脳トレ日和<br>毎日の脳トレで健康な生活を</p>
             <div class="footer-links">
                 <a href="privacy.html">プライバシーポリシー</a>
                 <a href="terms.html">利用規約</a>


### PR DESCRIPTION
## Summary
- フッターのコピー文言を2行表示に変更し、ハイフンを削除しました
- terms.html のフッター表記も同様に調整しました

## Testing
- 未実施


------
https://chatgpt.com/codex/tasks/task_e_68e4bdb033b4832fa92e447d80b23fe2