### PR TITLE
関連記事セクションを人気記事の6件グリッドに調整

### DIFF
--- a/src/lib/components/RelatedQuizSection.svelte
+++ b/src/lib/components/RelatedQuizSection.svelte
@@ -2,9 +2,11 @@
   import { createSanityImageSet } from '$lib/utils/images.js';
 
   export let quizzes = [];
-  export let heading = '関連記事';
   export let headingId = 'related-heading';
   export let fallbackImageUrl = '/logo.svg';
+
+  const MAX_ITEMS = 6;
+  const headingText = '関連記事';
 
   const formatDate = (value) => {
     if (!value) return '';
@@ -32,14 +34,14 @@
     return source?.asset?.metadata?.dimensions ?? { width: 480, height: 288 };
   };
 
-  $: items = Array.isArray(quizzes) ? quizzes : [];
+  $: items = Array.isArray(quizzes) ? quizzes.slice(0, MAX_ITEMS) : [];
   $: hasItems = items.length > 0;
 </script>
 
 {#if hasItems}
   <section class="related-section" aria-labelledby={headingId}>
     <div class="related-header">
-      <h2 id={headingId}>{heading}</h2>
+      <h2 id={headingId}>{headingText}</h2>
     </div>
     <div class="related-grid">
       {#each items as quiz (quiz.slug)}
@@ -52,20 +54,20 @@
                 <source
                   srcset={imageSet.avifSrcset}
                   type="image/avif"
-                  sizes="(min-width: 768px) 360px, 90vw"
+                  sizes="(min-width: 960px) 260px, (min-width: 640px) 45vw, 90vw"
                 />
               {/if}
               {#if imageSet.webpSrcset}
                 <source
                   srcset={imageSet.webpSrcset}
                   type="image/webp"
-                  sizes="(min-width: 768px) 360px, 90vw"
+                  sizes="(min-width: 960px) 260px, (min-width: 640px) 45vw, 90vw"
                 />
               {/if}
               <img
                 src={imageSet.src}
                 srcset={imageSet.srcset}
-                sizes="(min-width: 768px) 360px, 90vw"
+                sizes="(min-width: 960px) 260px, (min-width: 640px) 45vw, 90vw"
                 alt={`${quiz.title}の問題イメージ`}
                 loading="lazy"
                 decoding="async"
@@ -110,7 +112,7 @@
   .related-grid {
     display: grid;
     gap: 1.4rem;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    grid-template-columns: minmax(0, 1fr);
   }
 
   .related-card {
@@ -176,14 +178,26 @@
     color: #6b7280;
   }
 
+  @media (min-width: 640px) {
+    .related-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (min-width: 960px) {
+    .related-section {
+      padding: 32px 28px 36px;
+    }
+
+    .related-grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+  }
+
   @media (max-width: 768px) {
     .related-section {
       padding: 24px 18px 28px;
       gap: 1.5rem;
-    }
-
-    .related-grid {
-      grid-template-columns: minmax(0, 1fr);
     }
 
     .related-card {

--- a/src/lib/server/related-quizzes.js
+++ b/src/lib/server/related-quizzes.js
@@ -1,34 +1,15 @@
 import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
 
 const RELATED_QUERY = /* groq */ `{
-  "sameCategory": *[
-    _type == "quiz"
-    && defined(slug.current)
-    && !(_id in path("drafts.**"))
-    && slug.current != $slug
-    && $categorySlug != null
-    && defined(category._ref)
-    && category->slug.current == $categorySlug
-    && (!defined(publishedAt) || publishedAt <= now())
-  ] | order(coalesce(publishedAt, _createdAt) desc)[0...6]{
-    _id,
-    title,
-    "slug": slug.current,
-    category->{ title, "slug": slug.current },
-    mainImage{ asset->{ url, metadata } },
-    problemImage{ asset->{ url, metadata } },
-    publishedAt,
-    _createdAt
-  },
   "popular": *[
     _type == "quiz"
     && defined(slug.current)
     && !(_id in path("drafts.**"))
     && (!defined(publishedAt) || publishedAt <= now())
   ] | order(
-    coalesce(popularityScore, viewCount, totalViews, impressions, 0) desc,
+    coalesce(popularityScore, recentViewCount, viewCount, totalViews, impressions, 0) desc,
     coalesce(publishedAt, _createdAt) desc
-  )[0...8]{
+  )[0...18]{
     _id,
     title,
     "slug": slug.current,
@@ -36,7 +17,12 @@ const RELATED_QUERY = /* groq */ `{
     mainImage{ asset->{ url, metadata } },
     problemImage{ asset->{ url, metadata } },
     publishedAt,
-    _createdAt
+    _createdAt,
+    popularityScore,
+    viewCount,
+    recentViewCount,
+    totalViews,
+    impressions
   }
 }`;
 
@@ -51,6 +37,18 @@ const toPreview = (quiz) => {
   if (!quiz?.slug) return null;
   const image = pickImage(quiz);
   const publishedAt = quiz?.publishedAt ?? quiz?._createdAt;
+  const popularity =
+    typeof quiz?.popularityScore === 'number'
+      ? quiz.popularityScore
+      : typeof quiz?.recentViewCount === 'number'
+        ? quiz.recentViewCount
+        : typeof quiz?.viewCount === 'number'
+          ? quiz.viewCount
+          : typeof quiz?.totalViews === 'number'
+            ? quiz.totalViews
+            : typeof quiz?.impressions === 'number'
+              ? quiz.impressions
+              : 0;
   return {
     id: quiz._id ?? quiz.slug,
     title: quiz.title ?? '脳トレ問題',
@@ -58,7 +56,8 @@ const toPreview = (quiz) => {
     category: quiz.category ?? null,
     image,
     publishedAt,
-    createdAt: quiz?._createdAt
+    createdAt: quiz?._createdAt,
+    popularity
   };
 };
 
@@ -70,27 +69,57 @@ export async function fetchRelatedQuizzes({ slug, categorySlug }) {
       slug,
       categorySlug: categorySlug ?? null
     });
-    const sameCategory = Array.isArray(payload?.sameCategory)
-      ? payload.sameCategory.map(toPreview).filter(Boolean)
-      : [];
     const popular = Array.isArray(payload?.popular)
       ? payload.popular.map(toPreview).filter(Boolean)
       : [];
 
-    const filteredSameCategory = sameCategory.filter((item) => item.slug !== slug);
     const filteredPopular = popular.filter((item) => item.slug !== slug);
 
-    const merged = filteredSameCategory.slice(0, 6);
-    const seen = new Set(merged.map((item) => item.slug));
-
-    for (const item of filteredPopular) {
-      if (merged.length >= 6) break;
-      if (seen.has(item.slug)) continue;
-      merged.push(item);
-      seen.add(item.slug);
+    if (filteredPopular.length === 0) {
+      return [];
     }
 
-    return merged;
+    const recentThreshold = (() => {
+      const date = new Date();
+      date.setMonth(date.getMonth() - 3);
+      return date;
+    })();
+
+    const isRecent = (item) => {
+      const published = item?.publishedAt ?? item?.createdAt;
+      if (!published) return false;
+      const value = new Date(published);
+      if (Number.isNaN(value.getTime())) return false;
+      return value >= recentThreshold;
+    };
+
+    const selectItems = (source, seen, limit) => {
+      const results = [];
+      for (const item of source) {
+        if (results.length >= limit) break;
+        if (!item?.slug || seen.has(item.slug)) continue;
+        results.push(item);
+        seen.add(item.slug);
+      }
+      return results;
+    };
+
+    const sameCategoryPopular = filteredPopular.filter(
+      (item) => categorySlug && item?.category?.slug === categorySlug
+    );
+    const recentPopular = filteredPopular.filter(isRecent);
+    const recentSameCategory = sameCategoryPopular.filter(isRecent);
+
+    const seen = new Set();
+    const limit = 6;
+    const merged = [];
+
+    merged.push(...selectItems(recentSameCategory, seen, limit - merged.length));
+    merged.push(...selectItems(recentPopular, seen, limit - merged.length));
+    merged.push(...selectItems(sameCategoryPopular, seen, limit - merged.length));
+    merged.push(...selectItems(filteredPopular, seen, limit - merged.length));
+
+    return merged.slice(0, limit);
   } catch (error) {
     console.error('[related-quizzes] failed to fetch related quizzes', error);
     return [];


### PR DESCRIPTION
## Summary
- クイズ記事下の「関連記事」見出しを固定し、最大6件を3カラムグリッドで表示するように調整
- 人気記事を直近優先で取得するよう関連クエリと選定ロジックを更新

## Testing
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e4bf820bec832f80d9c32886cdb450