### PR TITLE
fix: 関連記事グリッドをPC3列・タブレット2列・スマホ1列に変更

### DIFF
--- a/src/lib/components/RelatedQuizSection.svelte
+++ b/src/lib/components/RelatedQuizSection.svelte
@@ -49,24 +49,24 @@
     font-weight: 800;
   }
 
-  /* PC: 4列 */
+  /* PC: 3列 */
   .related-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(3, 1fr);
     gap: 16px;
   }
 
-  /* タブレット: 3列 */
+  /* タブレット: 2列 */
   @media (max-width: 1023px) {
     .related-grid {
-      grid-template-columns: repeat(3, 1fr);
+      grid-template-columns: repeat(2, 1fr);
     }
   }
 
-  /* スマホ: 2列 */
+  /* スマホ: 1列 */
   @media (max-width: 639px) {
     .related-grid {
-      grid-template-columns: repeat(2, 1fr);
+      grid-template-columns: 1fr;
       gap: 12px;
     }
   }


### PR DESCRIPTION
## Summary
- PC（1024px以上）: 4列 → 3列×4行
- タブレット（640〜1023px）: 3列 → 2列×6行
- スマホ（639px以下）: 2列 → 1列×12行

## Test plan
- [ ] PCブラウザで関連記事が3列表示されること
- [ ] タブレット幅で2列表示されること
- [ ] スマホ幅で1列表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)