### PR TITLE
fix: www→apex domainへの301リダイレクト設定

### DIFF
--- a/static/3534fb42af494faeb537efd6a63e2bec.txt
+++ b/static/3534fb42af494faeb537efd6a63e2bec.txt
@@ -1,0 +1,1 @@
+3534fb42af494faeb537efd6a63e2bec

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "redirects": [
+    {
+      "source": "/:path*",
+      "has": [{ "type": "host", "value": "www.noutorebiyori.com" }],
+      "destination": "https://noutorebiyori.com/:path*",
+      "permanent": true
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- `vercel.json` を追加し、`www.noutorebiyori.com` から `noutorebiyori.com` への301リダイレクトを設定
- Search ConsoleでのURL正規化対応

## Test plan
- [ ] www.noutorebiyori.com にアクセスして noutorebiyori.com に301リダイレクトされることを確認
- [ ] Search Consoleでインデックス登録が改善されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)