### PR TITLE
fix: フッター固定ページリンク削除・サイドレール余白解消

### DIFF
--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -175,49 +175,7 @@ footer {
   text-align: center;
 }
 
-.footer-links {
-  margin: 1.25rem auto 0;
-  padding: 0;
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  width: 100%;
-  max-width: 320px;
-}
-
-.footer-links li {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.18);
-}
-
-.footer-links li:last-child {
-  border-bottom: none;
-}
-
-.footer-links a {
-  display: block;
-  padding: 0.35rem 0;
-  color: rgba(255, 255, 255, 0.85);
-  text-decoration: none;
-  transition: color 0.2s ease;
-}
-
-.footer-links a:hover,
-.footer-links a:focus-visible {
-  color: #ffffff;
-  text-decoration: underline;
-}
-
 @media (max-width: 768px) {
-  .logo-section {
-    flex-direction: row;
-  }
-
-  .logo-image {
-    width: 64px;
-    height: 64px;
-  }
-
   .nav-container {
     padding: 0 0.75rem;
     scroll-snap-type: x proximity;  /* 横スクロールの操作感UP */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -245,16 +245,6 @@
   <div class="footer-content">
     <p class="footer-copy">&copy; 2025年9月 脳トレ日和</p>
     <p class="footer-tagline">毎日の脳トレで健康な生活を</p>
-    <nav aria-label="法務および運営情報">
-      <ul class="footer-links">
-        <li><a href="/privacy-policy">プライバシーポリシー</a></li>
-        <li><a href="/about">運営者情報</a></li>
-        <li><a href="/contact">お問い合わせ</a></li>
-        <li><a href="/terms">利用規約</a></li>
-        <li><a href="/disclaimer">免責事項</a></li>
-        <li><a href="/about#author-info">著者情報</a></li>
-      </ul>
-    </nav>
   </div>
 </footer>
 
@@ -433,9 +423,12 @@
   .side-rail {
     display: none;
     position: fixed;
-    top: 100px; /* slim header + sticky nav の高さ分 */
+    top: 60px; /* slim header + sticky nav の高さ分 */
     width: 160px;
+    height: 0; /* flex コンテナに高さを与えない */
     z-index: 10; /* sticky nav (z-index:100) より下、コンテンツより上 */
+    flex: none;
+    overflow: visible;
   }
 
   .side-rail--left {


### PR DESCRIPTION
## Summary
- フッターの固定ページリンク一覧（プライバシーポリシー等）を削除（ハンバーガーメニューに移行済みのため）
- `aside.side-rail` に `height: 0; flex: none; overflow: visible` を追加し、flex コンテナへの高さ寄与をゼロに
- `global.css` から削除済み要素の stale な CSS（`.logo-section`・`.logo-image`・`.footer-links` 系）を除去
- サイドレール広告の `top` 値を slim ヘッダーに合わせて `60px` に調整

🤖 Generated with [Claude Code](https://claude.com/claude-code)