### PR TITLE
fix: ヘッダー復元・AdSense余白・メニュースクロール修正

### DIFF
--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -26,6 +26,9 @@ body {
   display: flex;
   flex-direction: column;
   -webkit-font-smoothing: antialiased;
+  /* AdSense Offer Wall が padding を body に注入するのを無効化 */
+  padding-top: 0 !important;
+  padding-bottom: 0 !important;
 }
 
 body[data-review-mode='true'] [data-monetize],

--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -47,9 +47,11 @@ img {
 
 header {
   background: linear-gradient(135deg, var(--primary-yellow) 0%, var(--primary-amber) 100%);
-  padding: 0.55rem 1rem;
-  box-shadow: 0 4px 16px rgba(255, 193, 7, 0.25);
+  text-align: center;
+  padding: 1rem;
+  box-shadow: 0 8px 24px rgba(255, 193, 7, 0.25);
   color: var(--dark-gray);
+  position: relative; /* ハンバーガーボタンの absolute 配置用 */
 }
 
 .header-content {
@@ -57,8 +59,39 @@ header {
   margin: 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
+  justify-content: center;
   gap: 1rem;
+}
+
+.logo-section {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  text-decoration: none;
+  color: inherit;
+  transition: transform 0.2s ease;
+}
+
+.logo-section:hover {
+  transform: scale(1.02);
+}
+
+.logo-image {
+  width: 80px;
+  height: 80px;
+  filter: drop-shadow(0 4px 12px rgba(0, 0, 0, 0.15));
+  background: var(--white);
+  border-radius: 16px;
+  padding: 8px;
+}
+
+.title-section {
+  text-align: left;
+}
+
+.subtitle {
+  font-size: 1rem;
+  color: #856404;
 }
 
 .main-nav {
@@ -176,6 +209,15 @@ footer {
 }
 
 @media (max-width: 768px) {
+  .logo-section {
+    flex-direction: row;
+  }
+
+  .logo-image {
+    width: 64px;
+    height: 64px;
+  }
+
   .nav-container {
     padding: 0 0.75rem;
     scroll-snap-type: x proximity;  /* 横スクロールの操作感UP */

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -345,6 +345,8 @@
     box-shadow: -4px 0 32px rgba(15, 23, 42, 0.2);
     overflow-y: auto;
     overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
     padding: 1.5rem 1.25rem 2rem;
     display: flex;
     flex-direction: column;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -142,20 +142,34 @@
 {#if ui.showHeader !== false}
   <header data-review-mode={reviewMode}>
     <div class="header-content">
-      <p class="header-brand">© 2025年9月 脳トレ日和 / 毎日の脳トレで健康な生活を</p>
-      <button
-        class="hamburger-btn"
-        type="button"
-        aria-label={menuOpen ? 'メニューを閉じる' : 'メニューを開く'}
-        aria-expanded={menuOpen}
-        aria-controls="site-menu"
-        on:click={toggleMenu}
-      >
-        <span class="hamburger-bar" class:open={menuOpen}></span>
-        <span class="hamburger-bar" class:open={menuOpen}></span>
-        <span class="hamburger-bar" class:open={menuOpen}></span>
-      </button>
+      <a href="/" class="logo-section" aria-label="脳トレ日和 トップページ">
+        <img
+          src="/logo.svg"
+          alt="脳トレ日和"
+          class="logo-image"
+          width="80"
+          height="80"
+          decoding="async"
+          fetchpriority="high"
+        />
+        <div class="title-section">
+          <h1>脳トレ日和</h1>
+          <p class="subtitle">楽しく脳を鍛えましょう</p>
+        </div>
+      </a>
     </div>
+    <button
+      class="hamburger-btn"
+      type="button"
+      aria-label={menuOpen ? 'メニューを閉じる' : 'メニューを開く'}
+      aria-expanded={menuOpen}
+      aria-controls="site-menu"
+      on:click={toggleMenu}
+    >
+      <span class="hamburger-bar" class:open={menuOpen}></span>
+      <span class="hamburger-bar" class:open={menuOpen}></span>
+      <span class="hamburger-bar" class:open={menuOpen}></span>
+    </button>
   </header>
 {/if}
 
@@ -260,17 +274,12 @@
     margin: 0.25rem 0;
   }
 
-  /* ── ヘッダー ────────────── */
-  .header-brand {
-    font-size: 0.85rem;
-    color: #78350f;
-    font-weight: 600;
-    margin: 0;
-    flex: 1;
-  }
-
   /* ── ハンバーガーボタン ────────────── */
   .hamburger-btn {
+    position: absolute;
+    right: 1rem;
+    top: 50%;
+    transform: translateY(-50%);
     display: flex;
     flex-direction: column;
     justify-content: center;
@@ -282,7 +291,6 @@
     border: 1.5px solid rgba(120, 53, 15, 0.25);
     border-radius: 8px;
     cursor: pointer;
-    flex-shrink: 0;
     transition: background 0.2s ease;
   }
 
@@ -423,7 +431,7 @@
   .side-rail {
     display: none;
     position: fixed;
-    top: 60px; /* slim header + sticky nav の高さ分 */
+    top: 140px; /* header + sticky nav の高さ分 */
     width: 160px;
     height: 0; /* flex コンテナに高さを与えない */
     z-index: 10; /* sticky nav (z-index:100) より下、コンテンツより上 */


### PR DESCRIPTION
## Summary

- ヘッダーのロゴ・サイト名・ハンバーガーボタンを復元し、ボタンをどのデバイスでも右端 1rem に固定配置
- AdSense Offer Wall が `body` に注入する `padding-bottom: 310px` を `!important` で無効化し、スマホのフッター下余白を解消
- ハンバーガーメニューパネルに `touch-action: pan-y` と `-webkit-overflow-scrolling: touch` を追加し、メニュー内スクロールを有効化

## Test plan

- [ ] PC・タブレット・スマホでヘッダーにロゴ・サイト名が表示されること
- [ ] ハンバーガーボタンが右端から 1rem の位置に表示されること
- [ ] スマホでフッター下にクリーム色余白が出ないこと
- [ ] ハンバーガーメニューを開いてパネル内をスクロールできること

🤖 Generated with [Claude Code](https://claude.com/claude-code)