### PR TITLE
fix: スマホ・PCの横スクロール（はみ出し）を根本修正

### DIFF
--- a/src/lib/components/AdSense.svelte
+++ b/src/lib/components/AdSense.svelte
@@ -136,14 +136,16 @@
   .adsense-container {
     position: relative;
     width: 100%;
+    max-width: 100%;
     display: block;
     text-align: center;
     /*
-     * overflow: hidden → visible に変更
-     * 「hidden」だとAdSenseが描画するiframeやバナー画像が
-     * コンテナ境界でクロップされる原因になるため削除。
+     * overflow-x: clip で横方向のはみ出しを防止しつつ、
+     * overflow-y: visible で縦方向の広告描画は許容する。
+     * hidden だとiframeがクロップされる原因になるため clip を使用。
      */
-    overflow: visible;
+    overflow-x: clip;
+    overflow-y: visible;
     line-height: 0;
     font-size: 0;
     box-sizing: border-box;

--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -4,6 +4,11 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: hidden;
+  max-width: 100%;
+}
+
 :root {
   --primary-yellow: #ffc107;
   --primary-amber: #f59e0b;
@@ -26,6 +31,8 @@ body {
   display: flex;
   flex-direction: column;
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden;
+  max-width: 100%;
   /* AdSense Offer Wall が padding を body に注入するのを無効化 */
   padding-top: 0 !important;
   padding-bottom: 0 !important;
@@ -249,7 +256,7 @@ footer {
 @media (min-width: 769px) {
   .nav-container {
     justify-content: center;
-    overflow-x: visible;  /* PCはスクロール不要 */
+    overflow-x: hidden;  /* PCはスクロール不要・はみ出しを隠す */
     touch-action: auto;
   }
 


### PR DESCRIPTION
## Summary

- `html` / `body` に `overflow-x: hidden` と `max-width: 100%` を追加し、全ページの横はみ出しをブロック
- `AdSense.svelte` のコンテナを `overflow: visible` → `overflow-x: clip; overflow-y: visible` + `max-width: 100%` に変更し、`data-full-width-responsive="true"` が注入する 100vw 幅の横はみ出しを防止（縦方向の描画は維持）
- カテゴリナビの PC 表示 (`overflow-x: visible`) を `overflow-x: hidden` に変更し、ナビアイテムのはみ出しを防止

## Test plan

- [ ] スマホで横スクロールが発生しないこと
- [ ] PCで横スクロールが発生しないこと
- [ ] AdSense 広告が正常に表示されること
- [ ] カテゴリナビがスマホで横スクロールできること（意図した動作）

🤖 Generated with [Claude Code](https://claude.com/claude-code)