### PR TITLE
fix: 横はみ出し根本修正・ヘッダーレイアウト整理

### DIFF
--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -4,11 +4,6 @@
   box-sizing: border-box;
 }
 
-html {
-  overflow-x: hidden;
-  max-width: 100%;
-}
-
 :root {
   --primary-yellow: #ffc107;
   --primary-amber: #f59e0b;
@@ -31,8 +26,6 @@ body {
   display: flex;
   flex-direction: column;
   -webkit-font-smoothing: antialiased;
-  overflow-x: hidden;
-  max-width: 100%;
   /* AdSense Offer Wall が padding を body に注入するのを無効化 */
   padding-top: 0 !important;
   padding-bottom: 0 !important;
@@ -57,11 +50,9 @@ img {
 
 header {
   background: linear-gradient(135deg, var(--primary-yellow) 0%, var(--primary-amber) 100%);
-  text-align: center;
   padding: 1rem;
   box-shadow: 0 8px 24px rgba(255, 193, 7, 0.25);
   color: var(--dark-gray);
-  position: relative; /* ハンバーガーボタンの absolute 配置用 */
 }
 
 .header-content {
@@ -69,7 +60,7 @@ header {
   margin: 0 auto;
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
   gap: 1rem;
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -157,19 +157,19 @@
           <p class="subtitle">楽しく脳を鍛えましょう</p>
         </div>
       </a>
+      <button
+        class="hamburger-btn"
+        type="button"
+        aria-label={menuOpen ? 'メニューを閉じる' : 'メニューを開く'}
+        aria-expanded={menuOpen}
+        aria-controls="site-menu"
+        on:click={toggleMenu}
+      >
+        <span class="hamburger-bar" class:open={menuOpen}></span>
+        <span class="hamburger-bar" class:open={menuOpen}></span>
+        <span class="hamburger-bar" class:open={menuOpen}></span>
+      </button>
     </div>
-    <button
-      class="hamburger-btn"
-      type="button"
-      aria-label={menuOpen ? 'メニューを閉じる' : 'メニューを開く'}
-      aria-expanded={menuOpen}
-      aria-controls="site-menu"
-      on:click={toggleMenu}
-    >
-      <span class="hamburger-bar" class:open={menuOpen}></span>
-      <span class="hamburger-bar" class:open={menuOpen}></span>
-      <span class="hamburger-bar" class:open={menuOpen}></span>
-    </button>
   </header>
 {/if}
 
@@ -274,12 +274,14 @@
     margin: 0.25rem 0;
   }
 
+  /* ── サイト名フォントサイズ ────────────── */
+  :global(.title-section h1) {
+    font-size: clamp(1.2rem, 4vw, 1.8rem);
+  }
+
   /* ── ハンバーガーボタン ────────────── */
   .hamburger-btn {
-    position: absolute;
-    right: 1rem;
-    top: 50%;
-    transform: translateY(-50%);
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
## Summary

**① 横スクロール根本修正**
- `html` / `body` の `overflow-x: hidden` を削除（左ズレ・広告の左切れの原因だった）
- 横はみ出しの本質的な原因は AdSense の `overflow-x: clip`（PR #500 で適用済み）で対処済みのため、body 側で隠す必要がなくなった

**② ヘッダーのサイト名とハンバーガーボタンの重なり解消**
- `.header-content` を `justify-content: center` → `space-between` に変更
- ハンバーガーボタンを `position: absolute` から `.header-content` 内のフレックス子要素（`flex-shrink: 0`）に変更
- サイト名 h1 に `font-size: clamp(1.2rem, 4vw, 1.8rem)` を適用し、スマホで自動縮小

## Test plan

- [ ] スマホでサイト名とハンバーガーボタンが重ならないこと
- [ ] PCでヘッダーが正常に表示されること
- [ ] 横スクロールが発生しないこと
- [ ] AdSense 広告の左右が切れていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)