### PR TITLE
fix: ロゴ中央配置・サブタイトル削除・スマホ横余白修正

### DIFF
--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -4,6 +4,10 @@
   box-sizing: border-box;
 }
 
+html {
+  overflow-x: clip; /* スマホでの横はみ出し防止（sticky要素に影響しない）*/
+}
+
 :root {
   --primary-yellow: #ffc107;
   --primary-amber: #f59e0b;
@@ -60,8 +64,8 @@ header {
   margin: 0 auto;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
+  justify-content: center;
+  position: relative;
 }
 
 .logo-section {
@@ -88,11 +92,6 @@ header {
 
 .title-section {
   text-align: left;
-}
-
-.subtitle {
-  font-size: 1rem;
-  color: #856404;
 }
 
 .main-nav {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -154,7 +154,6 @@
         />
         <div class="title-section">
           <h1>脳トレ日和</h1>
-          <p class="subtitle">楽しく脳を鍛えましょう</p>
         </div>
       </a>
       <button
@@ -281,7 +280,10 @@
 
   /* ── ハンバーガーボタン ────────────── */
   .hamburger-btn {
-    flex-shrink: 0;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
     display: flex;
     flex-direction: column;
     justify-content: center;


### PR DESCRIPTION
## Summary
- `header-content` を `justify-content: center` + `position: relative` に変更し、ロゴ・サイト名を真ん中に戻した
- ハンバーガーボタンを `position: absolute; right: 0` で右端に固定（フロー外なのでロゴと重ならない）
- 「楽しく脳を鍛えましょう」サブタイトル（`<p class="subtitle">`）と対応CSSを削除
- `html { overflow-x: clip }` を追加してスマホの左右余白（横はみ出し）を根本修正（`overflow-x: hidden` と異なり sticky要素に影響しない）

## Test plan
- [ ] スマホ表示でロゴ・サイト名が中央に表示されること
- [ ] ハンバーガーボタンが右端に表示され、サイト名と重ならないこと
- [ ] サブタイトル「楽しく脳を鍛えましょう」が非表示になっていること
- [ ] スマホで左右に余白が出ないこと（横スクロールしないこと）
- [ ] PC・タブレット表示で引き続き正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)