### PR TITLE
fix: スマホ横余白を根絶・PCハンバーガーを画面右端に修正

### DIFF
--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -5,7 +5,7 @@
 }
 
 html {
-  overflow-x: clip; /* スマホでの横はみ出し防止（sticky要素に影響しない）*/
+  overflow-x: hidden;
 }
 
 :root {
@@ -30,6 +30,7 @@ body {
   display: flex;
   flex-direction: column;
   -webkit-font-smoothing: antialiased;
+  overflow-x: hidden; /* スマホ横余白防止（html と二重指定で確実に封じる） */
   /* AdSense Offer Wall が padding を body に注入するのを無効化 */
   padding-top: 0 !important;
   padding-bottom: 0 !important;
@@ -57,6 +58,7 @@ header {
   padding: 1rem;
   box-shadow: 0 8px 24px rgba(255, 193, 7, 0.25);
   color: var(--dark-gray);
+  position: relative; /* ハンバーガーの absolute 基準を header 全幅にする */
 }
 
 .header-content {
@@ -65,7 +67,6 @@ header {
   display: flex;
   align-items: center;
   justify-content: center;
-  position: relative;
 }
 
 .logo-section {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -281,7 +281,7 @@
   /* ── ハンバーガーボタン ────────────── */
   .hamburger-btn {
     position: absolute;
-    right: 0;
+    right: 1rem; /* header の padding と揃えて画面右端に寄せる */
     top: 50%;
     transform: translateY(-50%);
     display: flex;


### PR DESCRIPTION
## Summary
- `html` + `body` 両方に `overflow-x: hidden` を設定し、スマホの右余白を確実に解消
  - 以前の `overflow-x: clip` はブラウザ（特にiOS Safari）によって効かない場合があるため `hidden` に変更
  - `html` だけでなく `body` にも二重指定することでより確実に封じる
- `header` に `position: relative` を移動（`.header-content` からは削除）
  - ハンバーガーボタンの absolute 基準が max-width 1200px のコンテナではなく **ヘッダー全幅** になる
- `.hamburger-btn` の `right: 0` → `right: 1rem` に変更
  - `header` の `padding: 1rem` と揃えて、PC・スマホともに画面右端に自然に収まる位置に修正

## Test plan
- [ ] スマホで右余白（横スクロール）が出ないこと
- [ ] PCでハンバーガーメニューが画面右端（padding分内側）に表示されること
- [ ] ロゴ・サイト名が中央に表示されること
- [ ] sticky ナビゲーションバーが正常にスクロール追従すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)