### PR TITLE
fix: スマホでコンテンツが左寄りになる問題を修正

### DIFF
--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -232,6 +232,11 @@ footer {
   }
 
   main {
+    width: 100%;
+    max-width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    box-sizing: border-box;
     padding: 1.5rem 1rem 1.5rem;
   }
 


### PR DESCRIPTION
## Summary
- モバイル（`max-width: 768px`）の `main` 要素に以下を追加
  - `width: 100%`
  - `max-width: 100%`
  - `margin-left: auto` / `margin-right: auto`
  - `box-sizing: border-box`
- PC・タブレット表示は変更なし

## 原因
`body { overflow-x: hidden }` によって body の内部レイアウト幅がビューポートより広くなる場合、`main { margin: 0 auto; max-width: 1200px }` がその広い幅を基準に中央寄せしてしまい、視覚的に左寄りに見える。`width: 100%; max-width: 100%` を明示することで body 幅に追従させ、横余白を出さずに中央に収める。

## Test plan
- [ ] スマホでコンテンツが画面中央に表示されること
- [ ] スマホで横余白（横スクロール）が発生しないこと
- [ ] PC・タブレットの表示が変わっていないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)