### PR TITLE
fix: AdSense広告の左端が切れる問題を修正

### DIFF
--- a/src/lib/components/AdSense.svelte
+++ b/src/lib/components/AdSense.svelte
@@ -139,7 +139,7 @@
     max-width: 100%;
     display: block;
     text-align: center;
-    overflow: hidden;
+    overflow: visible; /* hidden だと広告左端がクリップされる。親の overflow-x:clip が横スクロールを防ぐ */
     line-height: 0;
     font-size: 0;
     box-sizing: border-box;


### PR DESCRIPTION
## 原因
`AdSense.svelte` の `.adsense-container` に `overflow: hidden` が設定されており、AdSense が内部的に生成する iframe の位置がわずかにずれた場合に左端がクリップされていた。

## 修正内容
**`src/lib/components/AdSense.svelte` 1行のみ変更**

| 変更前 | 変更後 |
|---|---|
| `overflow: hidden` | `overflow: visible` |

## 横スクロールへの影響なし
広告コンテナの親要素がすでに `overflow-x: clip` を持っているため、`overflow: visible` にしても横スクロールは発生しない：
- `.quiz-detail { overflow-x: clip }` (QuizDetailPage.svelte)
- `.home-page { overflow-x: clip }` (+page.svelte)
- `main { overflow-x: clip }` (global.css)

## その他の設定（変更なし・すでに対応済み）
- `width: 100%` / `max-width: 100%` / `position: relative` → 設定済み
- `ins.adsbygoogle` に `width: 100% !important` / `max-width: 100% !important` → 設定済み
- `data-full-width-responsive="true"` → 設定済み

## Test plan
- [ ] スマホで広告の左端が切れずに表示されること
- [ ] 広告による横スクロールが発生しないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)