### PR TITLE
fix: 記事カードレイアウト改善（読了時間バッジ位置・余白縮小）

### DIFF
--- a/src/lib/components/ArticleCard.svelte
+++ b/src/lib/components/ArticleCard.svelte
@@ -122,11 +122,16 @@
             height={Math.round(dimensions.height)}
           />
         </picture>
-      {#if isNew}
-        <span class="thumb-badge thumb-badge--new">NEW</span>
-      {:else if categoryTitle}
-        <span class="thumb-badge" style="background:{categoryColor.bg};color:{categoryColor.text}">{categoryTitle}</span>
-      {/if}
+      <div class="thumb-badges">
+        {#if isNew}
+          <span class="thumb-badge thumb-badge--new">NEW</span>
+        {:else if categoryTitle}
+          <span class="thumb-badge" style="background:{categoryColor.bg};color:{categoryColor.text}">{categoryTitle}</span>
+        {/if}
+        {#if readingMinutes}
+          <span class="thumb-badge thumb-badge--time">⏱ {readingMinutes}分</span>
+        {/if}
+      </div>
       </div>
     {/if}
     <div class="article-card__content">
@@ -134,16 +139,11 @@
         <div class="article-card__date">{formattedDate}</div>
       {/if}
       <h3 class="article-card__title">{title}</h3>
-      {#if difficultyLabel || readingMinutes}
+      {#if difficultyLabel}
         <div class="article-card__badges">
-          {#if difficultyLabel}
-            <span class="badge badge--difficulty badge--{quiz.difficulty}">
-              {difficultyStars} {difficultyLabel}
-            </span>
-          {/if}
-          {#if readingMinutes}
-            <span class="badge badge--time">⏱ {readingMinutes}分</span>
-          {/if}
+          <span class="badge badge--difficulty badge--{quiz.difficulty}">
+            {difficultyStars} {difficultyLabel}
+          </span>
         </div>
       {/if}
     </div>
@@ -204,9 +204,9 @@
   }
 
   .article-card__content {
-    padding: 0.6rem 1.1rem 1.1rem;
+    padding: 0.4rem 1rem 0.8rem;
     display: grid;
-    gap: 0.25rem;
+    gap: 0.2rem;
     flex: 1;
   }
 
@@ -230,15 +230,15 @@
   .article-card__badges {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.35rem;
-    margin-top: 0.35rem;
+    gap: 0.25rem;
+    margin-top: 0.2rem;
   }
 
   .badge {
     display: inline-flex;
     align-items: center;
     gap: 0.2rem;
-    padding: 0.2rem 0.55rem;
+    padding: 0.15rem 0.45rem;
     border-radius: 999px;
     font-size: 0.75rem;
     font-weight: 700;
@@ -266,11 +266,17 @@
     color: #1e40af;
   }
 
-  .thumb-badge {
+  .thumb-badges {
     position: absolute;
     top: 8px;
     left: 8px;
     z-index: 2;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+  }
+
+  .thumb-badge {
     padding: 3px 8px;
     border-radius: 5px;
     font-size: 11px;
@@ -285,6 +291,13 @@
     font-size: 12px;
     padding: 4px 10px;
     box-shadow: 0 1px 4px rgba(226, 75, 74, 0.3);
+  }
+
+  .thumb-badge--time {
+    background: rgba(239, 246, 255, 0.92);
+    color: #1e40af;
+    font-size: 11px;
+    padding: 3px 8px;
   }
 
   @media (max-width: 520px) {


### PR DESCRIPTION
## 変更内容（ArticleCard.svelte のみ）

### ① 読了時間バッジを画像左上に移動
- `article-card__badges`（カード下部）から `⏱ N分` バッジを削除
- 画像上に `.thumb-badges` ラッパーを追加し、NEW / カテゴリバッジと横並び表示
- `.thumb-badge--time`（半透明白背景・青テキスト）スタイルを追加

**表示パターン：**
| 状態 | 画像左上に表示 |
|---|---|
| 新着あり + 読了時間あり | `NEW` `⏱ N分` |
| 新着なし + カテゴリあり + 読了時間あり | `カテゴリ名` `⏱ N分` |
| 読了時間なし | `NEW` または `カテゴリ名` のみ |

### ② 画像〜日付の余白を縮小
- `.article-card__content` padding-top: `0.6rem` → `0.4rem`（約67%）

### ③ カード全体をコンパクト化
| プロパティ | 変更前 | 変更後 |
|---|---|---|
| content padding | `0.6rem 1.1rem 1.1rem` | `0.4rem 1rem 0.8rem` |
| content gap | `0.25rem` | `0.2rem` |
| badges margin-top | `0.35rem` | `0.2rem` |
| badge padding | `0.2rem 0.55rem` | `0.15rem 0.45rem` |

色・フォント・角丸などのデザインは変更なし。PC・スマホ両方に適用。

## Test plan
- [ ] 記事カードの画像左上にNEW（または カテゴリ）バッジと読了時間バッジが横並びで表示されること
- [ ] カード下部に読了時間バッジが表示されないこと
- [ ] 画像〜日付の余白が以前より小さくなっていること
- [ ] カード全体の縦幅が少し小さくなっていること
- [ ] 難易度バッジはカード下部に残っていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)