### PR TITLE
fix: /category/kanji-quiz でクイズが0件になる問題を修正

### DIFF
--- a/src/routes/category/kanji-quiz/+page.server.js
+++ b/src/routes/category/kanji-quiz/+page.server.js
@@ -17,8 +17,8 @@ import { resolvePublishedDate } from '$lib/utils/publishedDate.js';
 
 export const prerender = false;
 
-const CATEGORY_SLUG = 'kanji-quiz';
-const CATEGORY_TITLE = '難読クイズ';
+const CATEGORY_SLUG = 'nandoku-kanji';
+const CATEGORY_TITLE = '難読漢字';
 
 const CATEGORY_QUERY = /* groq */ `
 *[_type == "category" && slug.current == $slug][0]{


### PR DESCRIPTION
## 原因
`src/routes/category/kanji-quiz/+page.server.js` の `CATEGORY_SLUG` が `'kanji-quiz'` になっていた。

Sanity 上のカテゴリスラッグは `'nandoku-kanji'` なので、GROQ クエリが常に0件を返していた。

## 変更内容（1ファイル・2行）

| 変数 | 変更前 | 変更後 |
|---|---|---|
| `CATEGORY_SLUG` | `'kanji-quiz'` | `'nandoku-kanji'` |
| `CATEGORY_TITLE` | `'難読クイズ'` | `'難読漢字'` |

## Test plan
- [ ] https://noutorebiyori.com/category/kanji-quiz にクイズが表示されること
- [ ] ページタイトル・SEOが「難読漢字」になっていること

🤖 Generated with [Claude Code](https://claude.com/claude-code)