### PR TITLE
fix: kanji-quiz カテゴリページで両スラッグのクイズを表示・ヘッダーフォント拡大

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -275,7 +275,7 @@
 
   /* ── サイト名フォントサイズ ────────────── */
   :global(.title-section h1) {
-    font-size: clamp(1.2rem, 4vw, 1.8rem);
+    font-size: clamp(1.45rem, 4.5vw, 2.1rem);
   }
 
   /* ── ハンバーガーボタン ────────────── */

--- a/src/routes/category/kanji-quiz/+page.server.js
+++ b/src/routes/category/kanji-quiz/+page.server.js
@@ -17,7 +17,8 @@ import { resolvePublishedDate } from '$lib/utils/publishedDate.js';
 
 export const prerender = false;
 
-const CATEGORY_SLUG = 'nandoku-kanji';
+// Sanity上に 'kanji-quiz' と 'nandoku-kanji' の2スラッグが混在しているため両方を対象にする
+const CATEGORY_SLUG = 'nandoku-kanji'; // カテゴリメタデータ取得用（正規スラッグ）
 const CATEGORY_TITLE = '難読漢字';
 
 const CATEGORY_QUERY = /* groq */ `
@@ -37,12 +38,13 @@ const parsePageParam = (value) => {
   return integer >= 1 ? integer : 1;
 };
 
+// クイズは 'kanji-quiz' と 'nandoku-kanji' 両スラッグを in 演算子で拾う
 const QUIZZES_BY_CATEGORY_QUERY = /* groq */ `{
   "newest": *[
     _type == "quiz"
     && defined(slug.current)
     && defined(category._ref)
-    && category->slug.current == $slug
+    && category->slug.current in ["kanji-quiz", "nandoku-kanji"]
     ${QUIZ_PUBLISHED_FILTER}
   ] | order(${QUIZ_ORDER_BY_PUBLISHED})[$offset...($offset + $limit)]{
     ${QUIZ_PREVIEW_PROJECTION}
@@ -51,7 +53,7 @@ const QUIZZES_BY_CATEGORY_QUERY = /* groq */ `{
     _type == "quiz"
     && defined(slug.current)
     && defined(category._ref)
-    && category->slug.current == $slug
+    && category->slug.current in ["kanji-quiz", "nandoku-kanji"]
     ${QUIZ_PUBLISHED_FILTER}
   ] | order(${QUIZ_ORDER_BY_PUBLISHED})[0...12]{
     ${QUIZ_PREVIEW_PROJECTION}
@@ -60,7 +62,7 @@ const QUIZZES_BY_CATEGORY_QUERY = /* groq */ `{
     _type == "quiz"
     && defined(slug.current)
     && defined(category._ref)
-    && category->slug.current == $slug
+    && category->slug.current in ["kanji-quiz", "nandoku-kanji"]
     ${QUIZ_PUBLISHED_FILTER}
   ]),
 }`;
@@ -165,7 +167,6 @@ export const load = async (event) => {
     const pageCategory = category || { title: CATEGORY_TITLE, slug: CATEGORY_SLUG };
 
     const quizzesResult = await client.fetch(QUIZZES_BY_CATEGORY_QUERY, {
-      slug: CATEGORY_SLUG,
       offset,
       limit: CATEGORY_PAGE_SIZE
     });


### PR DESCRIPTION
## 変更内容

### ① /category/kanji-quiz で全クイズを拾えるように修正

**原因**: Sanity上に `'kanji-quiz'` と `'nandoku-kanji'` の2種類のカテゴリスラッグが混在している。前回の修正で `CATEGORY_SLUG = 'nandoku-kanji'` にしたが、`/quiz/kanji-quiz/68` のようなクイズは `category->slug.current == 'kanji-quiz'` で登録されているため表示されなかった。

**修正**: GROQ クエリの条件を変更
```groq
// 変更前
&& category->slug.current == $slug

// 変更後
&& category->slug.current in ["kanji-quiz", "nandoku-kanji"]
```

`src/lib/server/related-quizzes.js` がすでに同じ `in` 演算子で両スラッグを扱っていたため、同じアプローチを採用。

### ② ヘッダー「脳トレ日和」フォントサイズ拡大

| 変更前 | 変更後 |
|---|---|
| `clamp(1.2rem, 4vw, 1.8rem)` | `clamp(1.45rem, 4.5vw, 2.1rem)` |

## Test plan
- [ ] `/category/kanji-quiz` に `/quiz/kanji-quiz/68` などのクイズが表示されること
- [ ] `nandoku-kanji` スラッグのクイズも引き続き表示されること
- [ ] ヘッダーの「脳トレ日和」が以前より少し大きく表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)