### PR TITLE
fix: kanji-quizカテゴリページで全クイズを表示（スラッグプレフィックス対応）

### DIFF
--- a/src/routes/category/kanji-quiz/+page.server.js
+++ b/src/routes/category/kanji-quiz/+page.server.js
@@ -38,13 +38,17 @@ const parsePageParam = (value) => {
   return integer >= 1 ? integer : 1;
 };
 
-// クイズは 'kanji-quiz' と 'nandoku-kanji' 両スラッグを in 演算子で拾う
+// カテゴリ参照あり（旧形式）とスラッグプレフィックス（新形式: kanji-quiz/71）の両方を拾う
+const KANJI_CATEGORY_FILTER = `(
+    category->slug.current in ["kanji-quiz", "nandoku-kanji"]
+    || string::split(slug.current, "/")[0] in ["kanji-quiz", "nandoku-kanji"]
+  )`;
+
 const QUIZZES_BY_CATEGORY_QUERY = /* groq */ `{
   "newest": *[
     _type == "quiz"
     && defined(slug.current)
-    && defined(category._ref)
-    && category->slug.current in ["kanji-quiz", "nandoku-kanji"]
+    && ${KANJI_CATEGORY_FILTER}
     ${QUIZ_PUBLISHED_FILTER}
   ] | order(${QUIZ_ORDER_BY_PUBLISHED})[$offset...($offset + $limit)]{
     ${QUIZ_PREVIEW_PROJECTION}
@@ -52,8 +56,7 @@ const QUIZZES_BY_CATEGORY_QUERY = /* groq */ `{
   "popular": *[
     _type == "quiz"
     && defined(slug.current)
-    && defined(category._ref)
-    && category->slug.current in ["kanji-quiz", "nandoku-kanji"]
+    && ${KANJI_CATEGORY_FILTER}
     ${QUIZ_PUBLISHED_FILTER}
   ] | order(${QUIZ_ORDER_BY_PUBLISHED})[0...12]{
     ${QUIZ_PREVIEW_PROJECTION}
@@ -61,8 +64,7 @@ const QUIZZES_BY_CATEGORY_QUERY = /* groq */ `{
   "total": count(*[
     _type == "quiz"
     && defined(slug.current)
-    && defined(category._ref)
-    && category->slug.current in ["kanji-quiz", "nandoku-kanji"]
+    && ${KANJI_CATEGORY_FILTER}
     ${QUIZ_PUBLISHED_FILTER}
   ]),
 }`;


### PR DESCRIPTION
## 根本原因

新形式クイズ（`/quiz/kanji-quiz/71` 等）はSanityの `category` 参照フィールドが**未設定**。

既存のクエリ条件:
```groq
&& defined(category._ref)                                    // ← ここで全件除外
&& category->slug.current in ["kanji-quiz", "nandoku-kanji"]
```

`category._ref` が null のため `defined()` が false → 0件になっていた。

## 修正内容

`defined(category._ref)` を削除し、**旧形式（category参照あり）と新形式（スラッグプレフィックス）の両方を OR で拾う**条件に変更:

```groq
&& (
  category->slug.current in ["kanji-quiz", "nandoku-kanji"]   // 旧形式
  || string::split(slug.current, "/")[0] in ["kanji-quiz", "nandoku-kanji"]  // 新形式
)
```

| 形式 | 例 | 対応方法 |
|---|---|---|
| 旧形式（category参照あり） | slug: `some-name`, category: `kanji-quiz` | `category->slug.current` で判定 |
| 新形式（プレフィックス形式） | slug: `kanji-quiz/71` | `string::split` で先頭セグメントを取得して判定 |

## Test plan
- [ ] `/category/kanji-quiz` に `/quiz/kanji-quiz/71` 等の新形式クイズが表示されること
- [ ] 旧形式クイズ（category参照あり）も引き続き表示されること
- [ ] 過去問題も含めて全件表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)