### PR TITLE
feat: グロナビから読解クイズ削除・PCスキルクイズ新設

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -190,6 +190,7 @@
           <li><a href="/category/kanji-quiz" on:click={closeMenu}>難読漢字</a></li>
           <li><a href="/category/business-manner" on:click={closeMenu}>ビジネスマナー</a></li>
           <li><a href="/category/number-quiz" on:click={closeMenu}>数字クイズ</a></li>
+          <li><a href="/category/pc-skill-quiz" on:click={closeMenu}>PCスキルクイズ</a></li>
         </ul>
       </nav>
 
@@ -214,7 +215,7 @@
     <div class="nav-container">
       <ul class="nav-menu">
         {#if data?.categories?.length}
-          {#each data.categories as c}
+          {#each data.categories.filter(c => c.title !== '読解クイズ') as c}
             <li>
               <a href={`/category/${c.slug}`} class="nav-link" data-sveltekit-preload-data
                 >{c.title}</a
@@ -230,6 +231,9 @@
         </li>
         <li>
           <a href="/category/number-quiz" class="nav-link" data-sveltekit-preload-data>数字クイズ</a>
+        </li>
+        <li>
+          <a href="/category/pc-skill-quiz" class="nav-link" data-sveltekit-preload-data>PCスキルクイズ</a>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
## 変更内容（+layout.svelte のみ）

### グロナビ（main-nav）
- `data.categories` ループに `.filter(c => c.title !== '読解クイズ')` を追加して読解クイズを非表示
- **PCスキルクイズ**（`/category/pc-skill-quiz`）を末尾に追加

### ハンバーガーメニュー
- 読解クイズは**そのまま維持**
- **PCスキルクイズ**（`/category/pc-skill-quiz`）を数字クイズの下に追加

## Test plan
- [ ] グロナビに「読解クイズ」が表示されないこと
- [ ] グロナビに「PCスキルクイズ」が表示されること
- [ ] ハンバーガーメニューに「読解クイズ」が引き続き表示されること
- [ ] ハンバーガーメニューに「PCスキルクイズ」が表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)