### PR TITLE
fix: 固定ページ法人化リニューアル（会社概要・各種ポリシー）

### DIFF
--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -1,192 +1,109 @@
-<script>
-  import SectionIcon from '$lib/components/SectionIcon.svelte';
-</script>
+<div class="static-page">
+  <h1 class="page-title">会社概要</h1>
 
-<div class="content-page">
-  <section class="page-content">
-    <h2 class="page-title">脳トレ日和について</h2>
+  <section class="section">
+    <h2>サイトについて</h2>
+    <p>脳トレ日和は、日常の中で楽しく脳を鍛えられる脳トレ・クイズコンテンツを提供するWebメディアです。難読漢字・マッチ棒クイズ・数字クイズなど、幅広い問題を無料でご利用いただけます。</p>
+  </section>
 
-    <div class="about-section">
-      <h3><SectionIcon name="brain-icon" className="section-icon" /> サイトの目的</h3>
-      <p>脳トレ日和は、日常生活の中で楽しく脳を鍛えることを目的とした無料の脳トレーニングサイトです。特に高齢者の方々が気軽に楽しめるよう、シンプルで分かりやすいデザインと操作性を重視して作られています。</p>
-    </div>
-
-    <div class="about-section">
-      <h3><SectionIcon name="features-icon" className="section-icon" /> サイトの特徴</h3>
-      <ul class="features-list">
-        <li><strong>シンプルな操作</strong> - 誰でも迷わず使える直感的なインターフェース</li>
-        <li><strong>見やすいデザイン</strong> - 大きな文字と温かみのある色合いで目に優しい</li>
-        <li><strong>段階的な難易度</strong> - レベルシステムで徐々にステップアップ</li>
-        <li><strong>無料でご利用</strong> - 登録不要で完全無料でお楽しみいただけます</li>
-        <li><strong>レスポンシブ対応</strong> - スマートフォンやタブレットでも快適に利用可能</li>
-      </ul>
-    </div>
-
-    <div class="about-section">
-      <h3><SectionIcon name="home-icon" className="section-icon" /> こんな方におすすめ</h3>
-      <ul class="target-users">
-        <li>日々の脳トレーニングを習慣にしたい方</li>
-        <li>記憶力や計算力の維持・向上を図りたい方</li>
-        <li>空いた時間に手軽に楽しめる娯楽をお探しの方</li>
-        <li>スマートフォンやパソコンで気軽にゲームを楽しみたい方</li>
-        <li>家族みんなで一緒に楽しめるコンテンツをお探しの方</li>
-      </ul>
-    </div>
-
-    <div class="about-section" id="author-info">
-      <h3><SectionIcon name="news-icon" className="section-icon" /> 著者情報</h3>
-      <div class="author-link-wrap">
-        <a href="/author/editorial-team" class="author-link-button">著者・編集部について詳しくはこちら →</a>
-      </div>
-    </div>
-
-    <div class="about-section" id="operator-info">
-      <h3><SectionIcon name="news-icon" className="section-icon" /> 運営者情報</h3>
-      <div class="operator-info">
-        <table class="info-table">
-          <tbody>
-          <tr>
-            <th>サイト名</th>
-            <td>脳トレ日和</td>
-          </tr>
-          <tr>
-            <th>運営者</th>
-            <td>脳トレ日和運営チーム</td>
-          </tr>
-          <tr>
-            <th>運用開始月</th>
-            <td>2025年9月</td>
-          </tr>
-          <tr>
-            <th>所在地</th>
-            <td>日本</td>
-          </tr>
-          <tr>
-            <th>連絡先</th>
-            <td><a href="/contact">お問い合わせフォーム</a></td>
-          </tr>
-          </tbody>
-        </table>
-      </div>
-    </div>
-
-    <div class="about-section">
-      <h3><SectionIcon name="clock-icon" className="section-icon" /> プライバシーと安全性</h3>
-      <p>当サイトでは、ユーザーの皆様の個人情報保護を最優先に考えています。</p>
-      <ul>
-        <li>個人情報の収集は最小限に留めています</li>
-        <li>SSL暗号化通信によりデータの安全性を確保</li>
-        <li>第三者への個人情報提供は行いません</li>
-        <li>詳細は<a href="/privacy-policy">プライバシーポリシー</a>をご確認ください</li>
-      </ul>
-    </div>
-
-    <div class="about-section">
-      <h3><SectionIcon name="trophy-icon" className="section-icon" /> 今後の展開</h3>
-      <p>脳トレ日和では、ユーザーの皆様からのフィードバックを基に、継続的にサイトの改善と新機能の追加を行っています。今後も更なる脳トレーニングコンテンツの充実を図り、より多くの方に愛されるサイトを目指します。</p>
-    </div>
-
-    <div class="cta-section">
-      <h3><SectionIcon name="game-icon" className="section-icon" /> さあ、始めましょう！</h3>
-      <p>脳トレ日和で楽しく脳を鍛えて、健康的な毎日を過ごしましょう。</p>
-      <a href="/" class="cta-button">ゲームを始める</a>
-    </div>
+  <section class="section">
+    <h2>会社概要</h2>
+    <table class="info-table">
+      <tbody>
+        <tr>
+          <th>会社名</th>
+          <td>合同会社NBWMedia</td>
+        </tr>
+        <tr>
+          <th>運営メディア</th>
+          <td>脳トレ日和</td>
+        </tr>
+        <tr>
+          <th>運営者</th>
+          <td>脳トレ日和編集部</td>
+        </tr>
+        <tr>
+          <th>所在地</th>
+          <td>東京都中央区銀座1丁目12番4号</td>
+        </tr>
+        <tr>
+          <th>設立</th>
+          <td>2026年4月</td>
+        </tr>
+        <tr>
+          <th>事業内容</th>
+          <td>Webメディア運営・コンテンツ制作</td>
+        </tr>
+        <tr>
+          <th>連絡先</th>
+          <td><a href="/contact">お問い合わせフォーム</a></td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </div>
 
 <style>
-  .content-page {
-    max-width: 800px;
+  .static-page {
+    max-width: 760px;
     margin: 0 auto;
-    padding: 2rem 1rem;
+    padding: 2rem 1rem 3rem;
   }
 
   .page-title {
-    font-size: 2.5rem;
-    color: #2d3436;
-    text-align: center;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #1f2937;
     margin-bottom: 2rem;
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 1.5rem;
-    border-radius: 15px;
-    box-shadow: 0 8px 32px rgba(255, 235, 59, 0.1);
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #ffc107;
   }
 
-  .about-section {
-    margin-bottom: 3rem;
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  .section {
+    margin-bottom: 2.5rem;
   }
 
-  .about-section h3 {
-    font-size: 1.5rem;
-    color: #2d3436;
+  .section h2 {
+    font-size: 1.15rem;
+    font-weight: 700;
+    color: #1f2937;
     margin-bottom: 1rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
+    padding-left: 0.75rem;
+    border-left: 3px solid #ffc107;
   }
 
-  :global(.section-icon) {
-    width: 24px;
-    height: 24px;
-    object-fit: contain;
-  }
-
-  .about-section p {
-    color: #636e72;
+  .section p {
+    color: #4b5563;
     line-height: 1.8;
-    margin-bottom: 1rem;
-  }
-
-  .features-list, .target-users {
-    list-style: none;
-    padding: 0;
-  }
-
-  .features-list li, .target-users li {
-    color: #636e72;
-    line-height: 1.8;
-    margin-bottom: 0.8rem;
-    padding-left: 1.5rem;
-    position: relative;
-  }
-
-  .features-list li::before, .target-users li::before {
-    content: "✓";
-    position: absolute;
-    left: 0;
-    color: #a08000;
-    font-weight: bold;
   }
 
   .info-table {
     width: 100%;
     border-collapse: collapse;
-    margin-top: 1rem;
   }
 
-  .info-table th, .info-table td {
-    padding: 1rem;
+  .info-table th,
+  .info-table td {
+    padding: 0.75rem 1rem;
     text-align: left;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid #e5e7eb;
+    font-size: 0.95rem;
+    vertical-align: top;
   }
 
   .info-table th {
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    color: #2d3436;
+    color: #1f2937;
     font-weight: 600;
-    width: 30%;
+    width: 35%;
+    background: #fafafa;
   }
 
   .info-table td {
-    color: #636e72;
+    color: #4b5563;
   }
 
   .info-table a {
-    color: #a08000;
+    color: #d97706;
     text-decoration: none;
   }
 
@@ -194,71 +111,15 @@
     text-decoration: underline;
   }
 
-  .author-link-wrap {
-    text-align: center;
-    margin-top: 1rem;
-  }
-
-  .author-link-button {
-    display: inline-block;
-    background: linear-gradient(135deg, #ffe082 0%, #fffacd 100%);
-    color: #a08000;
-    text-decoration: none;
-    padding: 1rem 2rem;
-    border-radius: 25px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(255, 235, 59, 0.3);
-  }
-
-  .author-link-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(255, 235, 59, 0.4);
-  }
-
-  .cta-section {
-    text-align: center;
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 2rem;
-    border-radius: 15px;
-    border: 2px solid rgba(255, 235, 59, 0.2);
-  }
-
-  .cta-button {
-    display: inline-block;
-    background: linear-gradient(135deg, #ffe082 0%, #fffacd 100%);
-    color: #a08000;
-    text-decoration: none;
-    padding: 1rem 2rem;
-    border-radius: 25px;
-    font-weight: 600;
-    margin-top: 1rem;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(255, 235, 59, 0.3);
-  }
-
-  .cta-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(255, 235, 59, 0.4);
-  }
-
-  @media (max-width: 768px) {
-    .content-page {
-      padding: 1rem;
+  @media (max-width: 600px) {
+    .info-table th {
+      width: 40%;
     }
 
-    .page-title {
-      font-size: 2rem;
-      padding: 1rem;
-    }
-
-    .about-section {
-      padding: 1.5rem;
-    }
-
-    .info-table th, .info-table td {
-      padding: 0.8rem;
+    .info-table th,
+    .info-table td {
+      padding: 0.6rem 0.75rem;
+      font-size: 0.9rem;
     }
   }
 </style>
-

--- a/src/routes/disclaimer/+page.svelte
+++ b/src/routes/disclaimer/+page.svelte
@@ -1,210 +1,163 @@
-<script>
-  import SectionIcon from '$lib/components/SectionIcon.svelte';
-</script>
+<div class="static-page">
+  <h1 class="page-title">免責事項</h1>
 
-<div class="content-page">
-  <section class="page-content">
-    <h2 class="page-title">免責事項</h2>
+  <div class="intro">
+    <p>合同会社NBWMedia（以下「当社」）が運営する脳トレ日和（以下「当サイト」）のコンテンツおよび広告をご利用いただく際の注意事項と責任範囲について定めています。ご利用の前に必ずご一読ください。</p>
+    <p class="last-updated">最終更新日：2026年4月1日</p>
+  </div>
 
-    <div class="policy-intro">
-      <p>脳トレ日和（以下「当サイト」）のコンテンツおよび広告をご利用いただく際の注意事項と責任範囲について定めています。ご利用の前に必ずご一読ください。</p>
-      <p class="last-updated">最終更新日：2025年9月1日</p>
-    </div>
+  <section class="section">
+    <h2>広告掲載について</h2>
+    <p>当サイトでは、第三者の広告配信サービスを利用して広告を掲載しています。広告の内容や表示方法は広告配信事業者が管理しており、当サイトは広告内容の正確性・信頼性・合法性を保証するものではありません。</p>
+    <ul>
+      <li>広告から表示される商品・サービスの品質や提供条件を保証いたしません。</li>
+      <li>広告表示によって生じるいかなる損害についても責任を負いかねます。</li>
+      <li>広告に関するお問い合わせは、直接広告主または広告配信事業者へご連絡ください。</li>
+    </ul>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="news-icon" className="section-icon" /> 広告掲載について</h3>
-      <div class="policy-content">
-        <p>当サイトでは、第三者の広告配信サービスを利用して広告を掲載しています。広告の内容や表示方法は広告配信事業者が管理しており、当サイトは広告内容の正確性・信頼性・合法性を保証するものではありません。</p>
-        <ul>
-          <li>広告から表示される商品・サービスの品質や提供条件を保証いたしません。</li>
-          <li>広告表示によって生じるいかなる損害についても責任を負いかねます。</li>
-          <li>広告に関するお問い合わせは、直接広告主または広告配信事業者へご連絡ください。</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>広告の閲覧・クリック後の責任</h2>
+    <p>広告をクリックした後の閲覧・利用・購入などの行為は、ユーザーご自身の判断と責任において行ってください。当サイトはユーザーと広告主との間で発生した取引やトラブルに一切関与いたしません。</p>
+    <ul>
+      <li>購入や申込を行う前に、広告主の利用規約や個人情報保護方針をご確認ください。</li>
+      <li>広告経由で発生した金銭的損害、紛争、契約上の問題について当サイトは責任を負いません。</li>
+      <li>広告先で入力する個人情報や決済情報の取扱いについては、各広告主の責任で管理されています。</li>
+    </ul>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="features-icon" className="section-icon" /> 広告の閲覧・クリック後の責任</h3>
-      <div class="policy-content">
-        <p>広告をクリックした後の閲覧・利用・購入などの行為は、ユーザーご自身の判断と責任において行ってください。当サイトはユーザーと広告主との間で発生した取引やトラブルに一切関与いたしません。</p>
-        <ul>
-          <li>購入や申込を行う前に、広告主の利用規約や個人情報保護方針をご確認ください。</li>
-          <li>広告経由で発生した金銭的損害、紛争、契約上の問題について当サイトは責任を負いません。</li>
-          <li>広告先で入力する個人情報や決済情報の取扱いについては、各広告主の責任で管理されています。</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>外部リンクについて</h2>
+    <p>当サイトのコンテンツ内には外部サイトへのリンクが含まれる場合があります。リンク先のサイトは当サイトの管理下にないため、掲載情報の正確性、安全性、合法性を保証するものではありません。</p>
+    <ul>
+      <li>外部リンク先で提供される商品・サービス・情報の利用により生じたいかなる損害についても責任を負いかねます。</li>
+      <li>リンク先の利用規約やプライバシーポリシーを必ずご確認ください。</li>
+      <li>リンク先の情報が変更・削除されている場合がありますので、最新の情報をご自身でご確認ください。</li>
+    </ul>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="home-icon" className="section-icon" /> 外部リンクについて</h3>
-      <div class="policy-content">
-        <p>当サイトのコンテンツ内には外部サイトへのリンクが含まれる場合があります。リンク先のサイトは当サイトの管理下にないため、掲載情報の正確性、安全性、合法性を保証するものではありません。</p>
-        <ul>
-          <li>外部リンク先で提供される商品・サービス・情報の利用により生じたいかなる損害についても責任を負いかねます。</li>
-          <li>リンク先の利用規約やプライバシーポリシーを必ずご確認ください。</li>
-          <li>リンク先の情報が変更・削除されている場合がありますので、最新の情報をご自身でご確認ください。</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>情報の正確性と更新について</h2>
+    <p>当サイトでは、正確で最新の情報を提供するよう努めていますが、掲載内容の完全性・正確性・最新性を保証するものではありません。</p>
+    <ul>
+      <li>コンテンツの情報が最新でない場合や誤りが含まれる場合があります。</li>
+      <li>予告なく情報の更新・修正・削除を行うことがあります。</li>
+      <li>当サイトの情報を利用した結果生じた損害については、当サイトでは責任を負いません。</li>
+    </ul>
+    <p>誤りや不明点を発見された場合は、<a href="/contact">お問い合わせフォーム</a>よりお知らせいただけますと幸いです。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="clock-icon" className="section-icon" /> 情報の正確性と更新について</h3>
-      <div class="policy-content">
-        <p>当サイトでは、正確で最新の情報を提供するよう努めていますが、掲載内容の完全性・正確性・最新性を保証するものではありません。</p>
-        <ul>
-          <li>コンテンツの情報が最新でない場合や誤りが含まれる場合があります。</li>
-          <li>予告なく情報の更新・修正・削除を行うことがあります。</li>
-          <li>当サイトの情報を利用した結果生じた損害については、当サイトでは責任を負いません。</li>
-        </ul>
-        <p>誤りや不明点を発見された場合は、<a href="/contact">お問い合わせフォーム</a>よりお知らせいただけますと幸いです。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>免責事項の変更</h2>
+    <p>本免責事項の内容は、必要に応じて予告なく変更することがあります。重要な変更がある場合は、当サイト上にてお知らせします。変更後の免責事項は、当サイトに掲載された時点で効力を生じるものとします。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="text-icon" className="section-icon" /> 免責事項の変更</h3>
-      <div class="policy-content">
-        <p>本免責事項の内容は、必要に応じて予告なく変更することがあります。重要な変更がある場合は、当サイト上にてお知らせします。</p>
-        <p>変更後の免責事項は、当サイトに掲載された時点で効力を生じるものとします。</p>
-      </div>
-    </div>
-
-    <div class="policy-section">
-      <h3><SectionIcon name="trophy-icon" className="section-icon" /> お問い合わせ窓口</h3>
-      <div class="policy-content">
-        <p>免責事項に関するご質問やご意見がございましたら、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
-        <div class="contact-info">
-          <h4>運営者情報</h4>
-          <table class="info-table">
-            <tbody>
-            <tr>
-              <th>サイト名</th>
-              <td>脳トレ日和</td>
-            </tr>
-            <tr>
-              <th>運営者</th>
-              <td>脳トレ日和運営チーム</td>
-            </tr>
-            <tr>
-              <th>運用開始月</th>
-              <td>2025年9月</td>
-            </tr>
-            <tr>
-              <th>連絡先</th>
-              <td><a href="/contact">お問い合わせフォーム</a></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-
-    <div class="back-to-home">
-      <a href="/" class="back-button">ホームに戻る</a>
-    </div>
+  <section class="section">
+    <h2>お問い合わせ</h2>
+    <p>免責事項に関するご質問やご意見がございましたら、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
+    <table class="info-table">
+      <tbody>
+        <tr>
+          <th>会社名</th>
+          <td>合同会社NBWMedia</td>
+        </tr>
+        <tr>
+          <th>運営メディア</th>
+          <td>脳トレ日和</td>
+        </tr>
+        <tr>
+          <th>運営者</th>
+          <td>脳トレ日和編集部</td>
+        </tr>
+        <tr>
+          <th>所在地</th>
+          <td>東京都中央区銀座1丁目12番4号</td>
+        </tr>
+        <tr>
+          <th>連絡先</th>
+          <td><a href="/contact">お問い合わせフォーム</a></td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </div>
 
 <style>
-  .content-page {
-    max-width: 800px;
+  .static-page {
+    max-width: 760px;
     margin: 0 auto;
-    padding: 2rem 1rem;
+    padding: 2rem 1rem 3rem;
   }
 
   .page-title {
-    font-size: 2.5rem;
-    color: #2d3436;
-    text-align: center;
-    margin-bottom: 2rem;
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 1.5rem;
-    border-radius: 15px;
-    box-shadow: 0 8px 32px rgba(255, 235, 59, 0.1);
-  }
-
-  .policy-intro {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    margin-bottom: 2rem;
-    text-align: center;
-  }
-
-  .policy-intro p {
-    color: #636e72;
-    line-height: 1.8;
-    margin-bottom: 1rem;
-  }
-
-  .last-updated {
-    font-size: 0.9rem;
-    color: #a08000;
-    font-weight: 600;
-  }
-
-  .policy-section {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    margin-bottom: 2rem;
-  }
-
-  .policy-section h3 {
-    font-size: 1.5rem;
-    color: #2d3436;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #1f2937;
     margin-bottom: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    border-bottom: 2px solid #fffacd;
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #ffc107;
   }
 
-  :global(.section-icon) {
-    width: 24px;
-    height: 24px;
-    object-fit: contain;
+  .intro {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
   }
 
-  .policy-content h4 {
-    color: #2d3436;
-    margin: 1.5rem 0 1rem 0;
-    font-size: 1.2rem;
-  }
-
-  .policy-content p {
-    color: #636e72;
+  .intro p {
+    color: #4b5563;
     line-height: 1.8;
-    margin-bottom: 1rem;
-  }
-
-  .policy-content ul {
-    color: #636e72;
-    line-height: 1.8;
-    margin-bottom: 1rem;
-    padding-left: 1.5rem;
-  }
-
-  .policy-content li {
     margin-bottom: 0.5rem;
   }
 
-  .policy-content a {
-    color: #a08000;
+  .last-updated {
+    font-size: 0.85rem;
+    color: #9ca3af;
+  }
+
+  .section {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .section:last-child {
+    border-bottom: none;
+  }
+
+  .section h2 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 0.75rem;
+    padding-left: 0.75rem;
+    border-left: 3px solid #ffc107;
+  }
+
+  .section p {
+    color: #4b5563;
+    line-height: 1.8;
+    margin-bottom: 0.75rem;
+  }
+
+  .section ul {
+    color: #4b5563;
+    line-height: 1.8;
+    padding-left: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .section li {
+    margin-bottom: 0.25rem;
+  }
+
+  .section a {
+    color: #d97706;
     text-decoration: none;
   }
 
-  .policy-content a:hover {
+  .section a:hover {
     text-decoration: underline;
-  }
-
-  .contact-info {
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 1.5rem;
-    border-radius: 12px;
-    margin-top: 1.5rem;
   }
 
   .info-table {
@@ -213,25 +166,28 @@
     margin-top: 1rem;
   }
 
-  .info-table th, .info-table td {
-    padding: 0.8rem;
+  .info-table th,
+  .info-table td {
+    padding: 0.65rem 1rem;
     text-align: left;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid #e5e7eb;
+    font-size: 0.9rem;
+    vertical-align: top;
   }
 
   .info-table th {
-    background: rgba(255, 250, 205, 0.5);
-    color: #2d3436;
+    color: #1f2937;
     font-weight: 600;
-    width: 30%;
+    width: 35%;
+    background: #fafafa;
   }
 
   .info-table td {
-    color: #636e72;
+    color: #4b5563;
   }
 
   .info-table a {
-    color: #a08000;
+    color: #d97706;
     text-decoration: none;
   }
 
@@ -239,47 +195,15 @@
     text-decoration: underline;
   }
 
-  .back-to-home {
-    text-align: center;
-  }
-
-  .back-button {
-    display: inline-block;
-    background: linear-gradient(135deg, #ffe082 0%, #fffacd 100%);
-    color: #a08000;
-    text-decoration: none;
-    padding: 1rem 2rem;
-    border-radius: 25px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(255, 235, 59, 0.3);
-  }
-
-  .back-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(255, 235, 59, 0.4);
-  }
-
-  @media (max-width: 768px) {
-    .content-page {
-      padding: 1rem;
+  @media (max-width: 600px) {
+    .info-table th {
+      width: 40%;
     }
 
-    .page-title {
-      font-size: 2rem;
-      padding: 1rem;
-    }
-
-    .policy-section {
-      padding: 1.5rem;
-    }
-
-    .policy-section h3 {
-      font-size: 1.3rem;
-    }
-
-    .info-table th, .info-table td {
-      padding: 0.6rem;
+    .info-table th,
+    .info-table td {
+      padding: 0.5rem 0.6rem;
+      font-size: 0.85rem;
     }
   }
 </style>

--- a/src/routes/privacy-policy/+page.svelte
+++ b/src/routes/privacy-policy/+page.svelte
@@ -1,286 +1,219 @@
-<script>
-  import SectionIcon from '$lib/components/SectionIcon.svelte';
-</script>
+<div class="static-page">
+  <h1 class="page-title">プライバシーポリシー</h1>
 
-<div class="content-page">
-  <section class="page-content">
-    <h2 class="page-title">プライバシーポリシー</h2>
-    
-    <div class="policy-intro">
-      <p>脳トレ日和（以下「当サイト」）は、ユーザーの皆様の個人情報保護を重要視し、以下のプライバシーポリシーに従って適切に取り扱います。</p>
-      <p class="last-updated">最終更新日：2025年9月1日</p>
-    </div>
+  <div class="intro">
+    <p>合同会社NBWMedia（以下「当社」）が運営する脳トレ日和（以下「当サイト」）は、ユーザーの皆様の個人情報保護を重要視し、以下のプライバシーポリシーに従って適切に取り扱います。</p>
+    <p class="last-updated">最終更新日：2026年4月1日</p>
+  </div>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="text-icon" className="section-icon" /> 1. 収集する情報</h3>
-      <div class="policy-content">
-        <h4>1.1 自動的に収集される情報</h4>
-        <ul>
-          <li>IPアドレス</li>
-          <li>ブラウザの種類とバージョン</li>
-          <li>オペレーティングシステム</li>
-          <li>アクセス日時</li>
-          <li>参照元URL</li>
-          <li>利用されたページ</li>
-        </ul>
+  <section class="section">
+    <h2>1. 収集する情報</h2>
+    <h3>1.1 自動的に収集される情報</h3>
+    <ul>
+      <li>IPアドレス</li>
+      <li>ブラウザの種類とバージョン</li>
+      <li>オペレーティングシステム</li>
+      <li>アクセス日時</li>
+      <li>参照元URL</li>
+      <li>利用されたページ</li>
+    </ul>
 
-        <h4>1.2 お問い合わせフォームで収集する情報</h4>
-        <ul>
-          <li>お名前</li>
-          <li>メールアドレス</li>
-          <li>お問い合わせ内容</li>
-        </ul>
-      </div>
-    </div>
+    <h3>1.2 お問い合わせフォームで収集する情報</h3>
+    <ul>
+      <li>お名前</li>
+      <li>メールアドレス</li>
+      <li>お問い合わせ内容</li>
+    </ul>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="clock-icon" className="section-icon" /> 2. 情報の利用目的</h3>
-      <div class="policy-content">
-        <p>収集した情報は以下の目的で利用いたします：</p>
-        <ul>
-          <li>サイトの運営・改善</li>
-          <li>お問い合わせへの対応</li>
-          <li>サイトの利用状況の分析</li>
-          <li>セキュリティの確保</li>
-          <li>法的義務の履行</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>2. 情報の利用目的</h2>
+    <p>収集した情報は以下の目的で利用いたします：</p>
+    <ul>
+      <li>サイトの運営・改善</li>
+      <li>お問い合わせへの対応</li>
+      <li>サイトの利用状況の分析</li>
+      <li>セキュリティの確保</li>
+      <li>法的義務の履行</li>
+    </ul>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="features-icon" className="section-icon" /> 3. 第三者への情報提供</h3>
-      <div class="policy-content">
-        <p>当サイトは、以下の場合を除き、収集した個人情報を第三者に提供することはありません：</p>
-        <ul>
-          <li>ユーザーの同意がある場合</li>
-          <li>法令に基づく場合</li>
-          <li>人の生命、身体または財産の保護のために必要がある場合</li>
-          <li>公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>3. 第三者への情報提供</h2>
+    <p>当サイトは、以下の場合を除き、収集した個人情報を第三者に提供することはありません：</p>
+    <ul>
+      <li>ユーザーの同意がある場合</li>
+      <li>法令に基づく場合</li>
+      <li>人の生命、身体または財産の保護のために必要がある場合</li>
+      <li>公衆衛生の向上または児童の健全な育成の推進のために特に必要がある場合</li>
+    </ul>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="trophy-icon" className="section-icon" /> 4. Cookieについて</h3>
-      <div class="policy-content">
-        <p>当サイトでは、サービスの向上のためにCookieを使用する場合があります。</p>
-        <h4>4.1 Cookieとは</h4>
-        <p>Cookieとは、ウェブサイトがユーザーのコンピュータに送信する小さなデータファイルです。</p>
-        
-        <h4>4.2 Cookieの利用目的</h4>
-        <ul>
-          <li>サイトの利用状況の分析</li>
-          <li>ユーザーの利便性向上</li>
-          <li>サイトの改善</li>
-        </ul>
+  <section class="section">
+    <h2>4. Cookieについて</h2>
+    <p>当サイトでは、サービスの向上のためにCookieを使用する場合があります。</p>
+    <h3>4.1 Cookieとは</h3>
+    <p>Cookieとは、ウェブサイトがユーザーのコンピュータに送信する小さなデータファイルです。</p>
+    <h3>4.2 Cookieの利用目的</h3>
+    <ul>
+      <li>サイトの利用状況の分析</li>
+      <li>ユーザーの利便性向上</li>
+      <li>サイトの改善</li>
+    </ul>
+    <h3>4.3 Cookieの無効化</h3>
+    <p>ブラウザの設定によりCookieを無効にすることができますが、一部機能が制限される場合があります。</p>
+  </section>
 
-        <h4>4.3 Cookieの無効化</h4>
-        <p>ブラウザの設定によりCookieを無効にすることができますが、一部機能が制限される場合があります。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>5. 広告配信について</h2>
+    <p>当サイトでは、Google AdSenseなどの第三者配信による広告サービスを利用する場合があります。これらの広告配信事業者は、ユーザーの興味・関心に応じた広告を表示するため、Cookieを使用してアクセス情報を収集することがあります。</p>
+    <h3>5.1 パーソナライズ広告の無効化</h3>
+    <p>Googleによる広告パーソナライズを無効にしたい場合は、<a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener">広告設定ページ</a>から設定を変更できます。</p>
+    <h3>5.2 Cookieの利用と第三者への情報提供</h3>
+    <p>Cookieによって取得される情報には、個人を特定できる情報は含まれません。Googleの広告サービスによるデータの取扱いについては、<a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener">Googleのポリシーと規約</a>をご確認ください。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="game-icon" className="section-icon" /> 5. 広告配信について</h3>
-      <div class="policy-content">
-        <p>当サイトでは、ユーザーに有益な情報を提供し続けるための収益確保を目的として、Google AdSenseなどの第三者配信による広告サービスを利用する場合があります。これらの広告配信事業者は、ユーザーの興味・関心に応じた広告を表示するため、Cookieを使用してアクセス情報を収集することがあります。</p>
-        <h4>5.1 パーソナライズ広告の無効化</h4>
-        <p>Googleによる広告パーソナライズを無効にしたい場合は、<a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener">広告設定ページ</a>から設定を変更できます。</p>
-        <h4>5.2 Cookieの利用と第三者への情報提供</h4>
-        <p>Cookieによって取得される情報には、氏名・住所・メールアドレス・電話番号など個人を特定できる情報は含まれません。また、Googleの広告サービスによるデータの取扱いについては、<a href="https://policies.google.com/technologies/ads" target="_blank" rel="noopener">Googleのポリシーと規約</a>をご確認ください。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>6. セキュリティ</h2>
+    <p>当サイトは、収集した個人情報の安全性を確保するため、SSL暗号化通信の使用および適切なアクセス制御を実施しています。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="brain-icon" className="section-icon" /> 6. セキュリティ</h3>
-      <div class="policy-content">
-        <p>当サイトは、収集した個人情報の安全性を確保するため、以下の対策を講じています：</p>
-        <ul>
-          <li>SSL暗号化通信の使用</li>
-          <li>適切なアクセス制御</li>
-          <li>定期的なセキュリティ監査</li>
-          <li>従業員への教育・研修</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>7. 個人情報の開示・訂正・削除</h2>
+    <p>ユーザーは、当サイトが保有する自己の個人情報について、開示・訂正・削除・利用停止を求める権利を有します。ご希望の場合は、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="home-icon" className="section-icon" /> 7. 個人情報の開示・訂正・削除</h3>
-      <div class="policy-content">
-        <p>ユーザーは、当サイトが保有する自己の個人情報について、以下の権利を有します：</p>
-        <ul>
-          <li>開示を求める権利</li>
-          <li>訂正・追加・削除を求める権利</li>
-          <li>利用停止・消去を求める権利</li>
-        </ul>
-        <p>これらの権利を行使される場合は、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>8. 外部サービスの利用</h2>
+    <h3>8.1 Google Analytics</h3>
+    <p>サイトの利用状況を分析するためにGoogle Analyticsを使用しています。詳細は<a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Googleのプライバシーポリシー</a>をご確認ください。</p>
+    <h3>8.2 Google AdSense</h3>
+    <p>広告配信の最適化や効果測定のためにGoogle AdSenseを利用する場合があります。詳細はGoogleの<a href="https://policies.google.com/privacy" target="_blank" rel="noopener">プライバシーポリシー</a>をご確認ください。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="news-icon" className="section-icon" /> 8. 外部サービスの利用</h3>
-      <div class="policy-content">
-        <p>当サイトでは、以下の外部サービスを利用する場合があります：</p>
+  <section class="section">
+    <h2>9. 未成年者の個人情報</h2>
+    <p>当サイトは、13歳未満の児童から個人情報を意図的に収集することはありません。13歳未満の児童が個人情報を提供した場合は、保護者の方は<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
+  </section>
 
-        <h4>8.1 Google Analytics</h4>
-        <p>サイトの利用状況を分析するためにGoogle Analyticsを使用しています。Google Analyticsは、Cookieを使用してユーザーの情報を収集します。詳細は<a href="https://policies.google.com/privacy" target="_blank" rel="noopener">Googleのプライバシーポリシー</a>をご確認ください。</p>
+  <section class="section">
+    <h2>10. プライバシーポリシーの変更</h2>
+    <p>当サイトは、必要に応じてプライバシーポリシーを変更する場合があります。重要な変更については、サイト上で通知いたします。</p>
+  </section>
 
-        <h4>8.2 Google AdSense</h4>
-        <p>広告配信の最適化や効果測定のためにGoogle AdSenseを利用する場合があります。Google AdSenseは、ユーザーの過去のアクセス情報に基づき広告を表示します。収集された情報の利用方法については、Googleの<a href="https://policies.google.com/privacy" target="_blank" rel="noopener">プライバシーポリシー</a>をご確認ください。</p>
-      </div>
-    </div>
-
-    <div class="policy-section">
-      <h3><SectionIcon name="game-icon" className="section-icon" /> 9. 未成年者の個人情報</h3>
-      <div class="policy-content">
-        <p>当サイトは、13歳未満の児童から個人情報を意図的に収集することはありません。13歳未満の児童が個人情報を提供した場合は、保護者の方は<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
-      </div>
-    </div>
-
-    <div class="policy-section">
-      <h3><SectionIcon name="text-icon" className="section-icon" /> 10. プライバシーポリシーの変更</h3>
-      <div class="policy-content">
-        <p>当サイトは、必要に応じてプライバシーポリシーを変更する場合があります。重要な変更については、サイト上で通知いたします。</p>
-      </div>
-    </div>
-
-    <div class="policy-section">
-      <h3><SectionIcon name="clock-icon" className="section-icon" /> 11. お問い合わせ</h3>
-      <div class="policy-content">
-        <p>プライバシーポリシーに関するご質問やご意見がございましたら、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
-        
-        <div class="contact-info">
-          <h4>運営者情報</h4>
-          <table class="info-table">
-            <tbody>
-            <tr>
-              <th>サイト名</th>
-              <td>脳トレ日和</td>
-            </tr>
-            <tr>
-              <th>運営者</th>
-              <td>脳トレ日和運営チーム</td>
-            </tr>
-            <tr>
-              <th>運用開始月</th>
-              <td>2025年9月</td>
-            </tr>
-            <tr>
-              <th>連絡先</th>
-              <td><a href="/contact">お問い合わせフォーム</a></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-
-    <div class="back-to-home">
-      <a href="/" class="back-button">ホームに戻る</a>
-    </div>
+  <section class="section">
+    <h2>11. お問い合わせ</h2>
+    <p>プライバシーポリシーに関するご質問は、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
+    <table class="info-table">
+      <tbody>
+        <tr>
+          <th>会社名</th>
+          <td>合同会社NBWMedia</td>
+        </tr>
+        <tr>
+          <th>運営メディア</th>
+          <td>脳トレ日和</td>
+        </tr>
+        <tr>
+          <th>運営者</th>
+          <td>脳トレ日和編集部</td>
+        </tr>
+        <tr>
+          <th>所在地</th>
+          <td>東京都中央区銀座1丁目12番4号</td>
+        </tr>
+        <tr>
+          <th>連絡先</th>
+          <td><a href="/contact">お問い合わせフォーム</a></td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </div>
 
 <style>
-  .content-page {
-    max-width: 800px;
+  .static-page {
+    max-width: 760px;
     margin: 0 auto;
-    padding: 2rem 1rem;
+    padding: 2rem 1rem 3rem;
   }
 
   .page-title {
-    font-size: 2.5rem;
-    color: #2d3436;
-    text-align: center;
-    margin-bottom: 2rem;
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 1.5rem;
-    border-radius: 15px;
-    box-shadow: 0 8px 32px rgba(255, 235, 59, 0.1);
-  }
-
-  .policy-intro {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    margin-bottom: 2rem;
-    text-align: center;
-  }
-
-  .policy-intro p {
-    color: #636e72;
-    line-height: 1.8;
-    margin-bottom: 1rem;
-  }
-
-  .last-updated {
-    font-size: 0.9rem;
-    color: #a08000;
-    font-weight: 600;
-  }
-
-  .policy-section {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
-    margin-bottom: 2rem;
-  }
-
-  .policy-section h3 {
-    font-size: 1.5rem;
-    color: #2d3436;
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #1f2937;
     margin-bottom: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    border-bottom: 2px solid #fffacd;
-    padding-bottom: 0.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #ffc107;
   }
 
-  :global(.section-icon) {
-    width: 24px;
-    height: 24px;
-    object-fit: contain;
+  .intro {
+    margin-bottom: 2rem;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
   }
 
-  .policy-content h4 {
-    color: #2d3436;
-    margin: 1.5rem 0 1rem 0;
-    font-size: 1.2rem;
-  }
-
-  .policy-content p {
-    color: #636e72;
+  .intro p {
+    color: #4b5563;
     line-height: 1.8;
-    margin-bottom: 1rem;
-  }
-
-  .policy-content ul {
-    color: #636e72;
-    line-height: 1.8;
-    margin-bottom: 1rem;
-    padding-left: 1.5rem;
-  }
-
-  .policy-content li {
     margin-bottom: 0.5rem;
   }
 
-  .policy-content a {
-    color: #a08000;
+  .last-updated {
+    font-size: 0.85rem;
+    color: #9ca3af;
+  }
+
+  .section {
+    margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid #e5e7eb;
+  }
+
+  .section:last-child {
+    border-bottom: none;
+  }
+
+  .section h2 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 0.75rem;
+    padding-left: 0.75rem;
+    border-left: 3px solid #ffc107;
+  }
+
+  .section h3 {
+    font-size: 0.95rem;
+    font-weight: 600;
+    color: #374151;
+    margin: 1rem 0 0.4rem;
+  }
+
+  .section p {
+    color: #4b5563;
+    line-height: 1.8;
+    margin-bottom: 0.75rem;
+  }
+
+  .section ul {
+    color: #4b5563;
+    line-height: 1.8;
+    padding-left: 1.5rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .section li {
+    margin-bottom: 0.25rem;
+  }
+
+  .section a {
+    color: #d97706;
     text-decoration: none;
   }
 
-  .policy-content a:hover {
+  .section a:hover {
     text-decoration: underline;
-  }
-
-  .contact-info {
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 1.5rem;
-    border-radius: 12px;
-    margin-top: 1.5rem;
   }
 
   .info-table {
@@ -289,25 +222,28 @@
     margin-top: 1rem;
   }
 
-  .info-table th, .info-table td {
-    padding: 0.8rem;
+  .info-table th,
+  .info-table td {
+    padding: 0.65rem 1rem;
     text-align: left;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid #e5e7eb;
+    font-size: 0.9rem;
+    vertical-align: top;
   }
 
   .info-table th {
-    background: rgba(255, 250, 205, 0.5);
-    color: #2d3436;
+    color: #1f2937;
     font-weight: 600;
-    width: 30%;
+    width: 35%;
+    background: #fafafa;
   }
 
   .info-table td {
-    color: #636e72;
+    color: #4b5563;
   }
 
   .info-table a {
-    color: #a08000;
+    color: #d97706;
     text-decoration: none;
   }
 
@@ -315,48 +251,15 @@
     text-decoration: underline;
   }
 
-  .back-to-home {
-    text-align: center;
-  }
-
-  .back-button {
-    display: inline-block;
-    background: linear-gradient(135deg, #ffe082 0%, #fffacd 100%);
-    color: #a08000;
-    text-decoration: none;
-    padding: 1rem 2rem;
-    border-radius: 25px;
-    font-weight: 600;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 15px rgba(255, 235, 59, 0.3);
-  }
-
-  .back-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 8px 25px rgba(255, 235, 59, 0.4);
-  }
-
-  @media (max-width: 768px) {
-    .content-page {
-      padding: 1rem;
+  @media (max-width: 600px) {
+    .info-table th {
+      width: 40%;
     }
 
-    .page-title {
-      font-size: 2rem;
-      padding: 1rem;
-    }
-
-    .policy-section {
-      padding: 1.5rem;
-    }
-
-    .policy-section h3 {
-      font-size: 1.3rem;
-    }
-
-    .info-table th, .info-table td {
-      padding: 0.6rem;
+    .info-table th,
+    .info-table td {
+      padding: 0.5rem 0.6rem;
+      font-size: 0.85rem;
     }
   }
 </style>
-

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -1,224 +1,178 @@
-<script>
-  import SectionIcon from '$lib/components/SectionIcon.svelte';
-</script>
+<div class="static-page">
+  <h1 class="page-title">利用規約</h1>
 
-<div class="content-page">
-  <section class="page-content">
-    <h2 class="page-title">利用規約</h2>
+  <div class="intro">
+    <p>この利用規約（以下「本規約」）は、合同会社NBWMedia（以下「当社」）が運営する脳トレ日和（以下「当サイト」）が提供するサービスの利用条件を定めるものです。ご利用に先立ち、本規約を必ずご確認ください。</p>
+    <p class="last-updated">最終更新日：2026年4月1日</p>
+  </div>
 
-    <div class="policy-intro">
-      <p>この利用規約（以下「本規約」）は、脳トレ日和（以下「当サイト」）が提供するサービスの利用条件を定めるものです。ご利用に先立ち、本規約を必ずご確認ください。</p>
-      <p class="last-updated">最終更新日：2025年9月1日</p>
-    </div>
+  <section class="section">
+    <h2>第1条（適用）</h2>
+    <p>本規約は、当サイトの提供するコンテンツ、機能、各種サービスに適用されます。ユーザーが当サイトを閲覧・利用した時点で、本規約に同意したものとみなします。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="text-icon" className="section-icon" /> 第1条（適用）</h3>
-      <div class="policy-content">
-        <p>本規約は、当サイトの提供するコンテンツ、機能、各種サービスに適用されます。ユーザーが当サイトを閲覧・利用した時点で、本規約に同意したものとみなします。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第2条（利用条件）</h2>
+    <p>当サイトは登録不要でご利用いただけますが、お問い合わせ等で情報を送信する際は、正確かつ最新の情報をご入力ください。未成年の方が利用する場合は、保護者の同意を得た上でご利用ください。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="clock-icon" className="section-icon" /> 第2条（利用条件）</h3>
-      <div class="policy-content">
-        <p>当サイトは登録不要でご利用いただけますが、お問い合わせ等で情報を送信する際は、正確かつ最新の情報をご入力ください。未成年の方が利用する場合は、保護者の同意を得た上でご利用ください。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第3条（禁止事項）</h2>
+    <p>ユーザーは、当サイトの利用にあたり以下の行為を行ってはなりません。</p>
+    <ul>
+      <li>法令または公序良俗に違反する行為</li>
+      <li>犯罪行為に関連する行為</li>
+      <li>当サイトのサーバーやネットワークの機能を妨害する行為</li>
+      <li>当サイトの運営を阻害する恐れのある行為</li>
+      <li>他のユーザーの個人情報等を収集・蓄積する行為</li>
+      <li>当サイトの許可なく広告、宣伝、勧誘を行う行為</li>
+      <li>その他、当サイトが不適切と判断する行為</li>
+    </ul>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="features-icon" className="section-icon" /> 第3条（禁止事項）</h3>
-      <div class="policy-content">
-        <p>ユーザーは、当サイトの利用にあたり以下の行為を行ってはなりません。</p>
-        <ul>
-          <li>法令または公序良俗に違反する行為</li>
-          <li>犯罪行為に関連する行為</li>
-          <li>当サイトのサーバーやネットワークの機能を妨害する行為</li>
-          <li>当サイトの運営を阻害する恐れのある行為</li>
-          <li>他のユーザーの個人情報等を収集・蓄積する行為</li>
-          <li>当サイトの許可なく広告、宣伝、勧誘を行う行為</li>
-          <li>その他、当サイトが不適切と判断する行為</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第4条（サービスの提供停止等）</h2>
+    <p>当サイトは、以下の事由があると判断した場合、ユーザーに事前通知することなくサービスの全部または一部を停止・中断することができます。</p>
+    <ul>
+      <li>システム保守や点検、改修を行う場合</li>
+      <li>地震、落雷、火災、停電、天災などの不可抗力によって提供が困難となった場合</li>
+      <li>通信回線やコンピュータの障害が発生した場合</li>
+      <li>その他、運営上サービス提供が困難と判断した場合</li>
+    </ul>
+    <p>これらの事由によりユーザーに生じた損害について、当サイトは責任を負いません。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="home-icon" className="section-icon" /> 第4条（サービスの提供停止等）</h3>
-      <div class="policy-content">
-        <p>当サイトは、以下の事由があると判断した場合、ユーザーに事前通知することなくサービスの全部または一部を停止・中断することができます。</p>
-        <ul>
-          <li>システム保守や点検、改修を行う場合</li>
-          <li>地震、落雷、火災、停電、天災などの不可抗力によって提供が困難となった場合</li>
-          <li>通信回線やコンピュータの障害が発生した場合</li>
-          <li>その他、運営上サービス提供が困難と判断した場合</li>
-        </ul>
-        <p>これらの事由によりユーザーに生じた損害について、当サイトは責任を負いません。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第5条（知的財産権）</h2>
+    <p>当サイトに掲載される文章、画像、動画、プログラムその他のコンテンツの著作権・商標権等の知的財産権は、当社または正当な権利者に帰属します。ユーザーは、私的利用の範囲を超えてこれらのコンテンツを使用できません。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="brain-icon" className="section-icon" /> 第5条（知的財産権）</h3>
-      <div class="policy-content">
-        <p>当サイトに掲載される文章、画像、動画、プログラムその他のコンテンツの著作権・商標権等の知的財産権は、当サイトまたは正当な権利者に帰属します。ユーザーは、私的利用の範囲を超えてこれらのコンテンツを使用できません。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第6条（免責事項）</h2>
+    <p>当サイトは、提供するコンテンツの正確性・有用性・適合性について保証いたしません。ユーザーが当サイトの情報を利用したことにより生じた損害について、当サイトは一切の責任を負いません。</p>
+    <p>詳細については、別途定める<a href="/disclaimer">免責事項</a>をご参照ください。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="news-icon" className="section-icon" /> 第6条（免責事項）</h3>
-      <div class="policy-content">
-        <p>当サイトは、提供するコンテンツの正確性・有用性・適合性について保証いたしません。ユーザーが当サイトの情報を利用したことにより生じた損害について、当サイトは一切の責任を負いません。</p>
-        <p>詳細については、別途定める<a href="/disclaimer">免責事項</a>をご参照ください。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第7条（広告について）</h2>
+    <p>当サイトでは、Google AdSenseを含む第三者配信の広告サービスを利用する場合があります。これらの広告配信事業者は、ユーザーの閲覧履歴に基づいて広告を表示するためCookieを使用することがあります。詳細は<a href="/privacy-policy">プライバシーポリシー</a>をご確認ください。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="game-icon" className="section-icon" /> 第7条（広告について）</h3>
-      <div class="policy-content">
-        <p>当サイトでは、Google AdSenseを含む第三者配信の広告サービスを利用する場合があります。これらの広告配信事業者は、ユーザーの興味や閲覧履歴に基づいて広告を表示するため、Cookieなどを使用して情報を収集することがあります。</p>
-        <ul>
-          <li>取得される情報に個人を特定できるデータは含まれません。</li>
-          <li>広告設定は<a href="https://adssettings.google.com/authenticated" target="_blank" rel="noopener">Googleの広告設定ページ</a>から変更できます。</li>
-          <li>詳細は<a href="/privacy-policy">プライバシーポリシー</a>をご確認ください。</li>
-        </ul>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第8条（利用規約の変更）</h2>
+    <p>当サイトは、必要と判断した場合には、ユーザーに通知することなく本規約を変更することができます。変更後の規約は、当サイトに掲載された時点から効力を生じるものとします。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="trophy-icon" className="section-icon" /> 第8条（利用規約の変更）</h3>
-      <div class="policy-content">
-        <p>当サイトは、必要と判断した場合には、ユーザーに通知することなく本規約を変更することができます。変更後の規約は、当サイトに掲載された時点から効力を生じるものとします。</p>
-      </div>
-    </div>
+  <section class="section">
+    <h2>第9条（準拠法および裁判管轄）</h2>
+    <p>本規約の解釈にあたっては日本法を準拠法とします。当サイトの利用に関して紛争が生じた場合、当社の所在地を管轄する地方裁判所を第一審の専属的合意管轄裁判所とします。</p>
+  </section>
 
-    <div class="policy-section">
-      <h3><SectionIcon name="clock-icon" className="section-icon" /> 第9条（準拠法および裁判管轄）</h3>
-      <div class="policy-content">
-        <p>本規約の解釈にあたっては日本法を準拠法とします。当サイトの利用に関して紛争が生じた場合、当サイトの運営拠点を管轄する地方裁判所を第一審の専属的合意管轄裁判所とします。</p>
-      </div>
-    </div>
-
-    <div class="policy-section">
-      <h3><SectionIcon name="features-icon" className="section-icon" /> 第10条（お問い合わせ）</h3>
-      <div class="policy-content">
-        <p>本規約に関するお問い合わせは、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
-        <div class="contact-info">
-          <h4>運営者情報</h4>
-          <table class="info-table">
-            <tbody>
-            <tr>
-              <th>サイト名</th>
-              <td>脳トレ日和</td>
-            </tr>
-            <tr>
-              <th>運営者</th>
-              <td>脳トレ日和運営チーム</td>
-            </tr>
-            <tr>
-              <th>運用開始月</th>
-              <td>2025年9月</td>
-            </tr>
-            <tr>
-              <th>連絡先</th>
-              <td><a href="/contact">お問い合わせフォーム</a></td>
-            </tr>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-
-    <div class="back-to-home">
-      <a href="/" class="back-button">ホームに戻る</a>
-    </div>
+  <section class="section">
+    <h2>第10条（お問い合わせ）</h2>
+    <p>本規約に関するお問い合わせは、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
+    <table class="info-table">
+      <tbody>
+        <tr>
+          <th>会社名</th>
+          <td>合同会社NBWMedia</td>
+        </tr>
+        <tr>
+          <th>運営メディア</th>
+          <td>脳トレ日和</td>
+        </tr>
+        <tr>
+          <th>運営者</th>
+          <td>脳トレ日和編集部</td>
+        </tr>
+        <tr>
+          <th>所在地</th>
+          <td>東京都中央区銀座1丁目12番4号</td>
+        </tr>
+        <tr>
+          <th>連絡先</th>
+          <td><a href="/contact">お問い合わせフォーム</a></td>
+        </tr>
+      </tbody>
+    </table>
   </section>
 </div>
 
 <style>
-  .content-page {
-    max-width: 800px;
+  .static-page {
+    max-width: 760px;
     margin: 0 auto;
-    padding: 2rem 1rem;
+    padding: 2rem 1rem 3rem;
   }
 
   .page-title {
-    font-size: 2.5rem;
-    color: #2d3436;
-    text-align: center;
-    margin-bottom: 2rem;
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    padding: 1.5rem;
-    border-radius: 15px;
-    box-shadow: 0 8px 32px rgba(255, 235, 59, 0.1);
+    font-size: 1.75rem;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 1.5rem;
+    padding-bottom: 0.75rem;
+    border-bottom: 2px solid #ffc107;
   }
 
-  .policy-intro {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  .intro {
     margin-bottom: 2rem;
-    text-align: center;
+    padding-bottom: 1.5rem;
+    border-bottom: 1px solid #e5e7eb;
   }
 
-  .policy-intro p {
-    color: #636e72;
+  .intro p {
+    color: #4b5563;
     line-height: 1.8;
-    margin-bottom: 1rem;
+    margin-bottom: 0.5rem;
   }
 
   .last-updated {
-    font-size: 0.9rem;
-    color: #a08000;
-    font-weight: 600;
+    font-size: 0.85rem;
+    color: #9ca3af;
   }
 
-  .policy-section {
-    background: white;
-    padding: 2rem;
-    border-radius: 15px;
-    box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+  .section {
     margin-bottom: 2rem;
+    padding-bottom: 2rem;
+    border-bottom: 1px solid #e5e7eb;
   }
 
-  .policy-section h3 {
-    font-size: 1.5rem;
-    color: #2d3436;
-    margin-bottom: 1.5rem;
-    display: flex;
-    align-items: center;
-    gap: 0.5rem;
-    border-bottom: 2px solid #fffacd;
-    padding-bottom: 0.5rem;
+  .section:last-child {
+    border-bottom: none;
   }
 
-  :global(.section-icon) {
-    width: 24px;
-    height: 24px;
-    object-fit: contain;
+  .section h2 {
+    font-size: 1.1rem;
+    font-weight: 700;
+    color: #1f2937;
+    margin-bottom: 0.75rem;
+    padding-left: 0.75rem;
+    border-left: 3px solid #ffc107;
   }
 
-  .policy-content p {
-    color: #636e72;
+  .section p {
+    color: #4b5563;
     line-height: 1.8;
-    margin-bottom: 1rem;
+    margin-bottom: 0.75rem;
   }
 
-  .policy-content ul {
-    color: #636e72;
+  .section ul {
+    color: #4b5563;
     line-height: 1.8;
-    margin-bottom: 1rem;
     padding-left: 1.5rem;
+    margin-bottom: 0.75rem;
   }
 
-  .policy-content li {
-    margin-bottom: 0.6rem;
+  .section li {
+    margin-bottom: 0.25rem;
   }
 
-  .policy-content a {
-    color: #a08000;
+  .section a {
+    color: #d97706;
     text-decoration: none;
   }
 
-  .policy-content a:hover {
+  .section a:hover {
     text-decoration: underline;
   }
 
@@ -230,37 +184,42 @@
 
   .info-table th,
   .info-table td {
-    padding: 1rem;
+    padding: 0.65rem 1rem;
     text-align: left;
-    border-bottom: 1px solid #dee2e6;
+    border-bottom: 1px solid #e5e7eb;
+    font-size: 0.9rem;
+    vertical-align: top;
   }
 
   .info-table th {
-    background: linear-gradient(135deg, #fffacd 0%, #fff0b3 100%);
-    color: #2d3436;
+    color: #1f2937;
     font-weight: 600;
-    width: 30%;
+    width: 35%;
+    background: #fafafa;
   }
 
-  .back-to-home {
-    text-align: center;
-    margin-top: 2rem;
+  .info-table td {
+    color: #4b5563;
   }
 
-  .back-button {
-    display: inline-block;
-    padding: 0.75rem 2.5rem;
-    border-radius: 999px;
-    background: linear-gradient(135deg, #ffe082 0%, #fffacd 100%);
-    color: #a08000;
+  .info-table a {
+    color: #d97706;
     text-decoration: none;
-    font-weight: 600;
-    box-shadow: 0 6px 16px rgba(255, 224, 130, 0.4);
-    transition: transform 0.2s ease, box-shadow 0.2s ease;
   }
 
-  .back-button:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 12px 24px rgba(255, 224, 130, 0.5);
+  .info-table a:hover {
+    text-decoration: underline;
+  }
+
+  @media (max-width: 600px) {
+    .info-table th {
+      width: 40%;
+    }
+
+    .info-table th,
+    .info-table td {
+      padding: 0.5rem 0.6rem;
+      font-size: 0.85rem;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary
- 固定ページ4ページ（会社概要・プライバシーポリシー・利用規約・免責事項）をシンプルなデザインに全面リニューアル
- SectionIcon コンポーネントと各見出し前の絵文字をすべて削除
- 運営者情報を「合同会社NBWMedia」の会社概要テーブルに更新（所在地・設立・事業内容を追記）
- 最終更新日を2026年4月1日に更新

## 変更内容
- `about/+page.svelte`: ページタイトルを「会社概要」に変更、不要セクション（著者情報・こんな方におすすめ・今後の展開・CTA等）を削除
- `privacy-policy/+page.svelte` / `terms/+page.svelte` / `disclaimer/+page.svelte`: 運営者情報テーブルを会社概要に差し替え、日付更新

## Test plan
- [ ] `/about` が「会社概要」として表示される
- [ ] `/privacy-policy`・`/terms`・`/disclaimer` の会社情報が合同会社NBWMediaになっている
- [ ] 絵文字・SectionIconが表示されていない
- [ ] スマホ・PC両方でレイアウト崩れなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)