### PR TITLE
fix: 著者ページ改善・固定ページTOP導線・ヘッダーサイト名中央揃え

### DIFF
--- a/src/lib/styles/global.css
+++ b/src/lib/styles/global.css
@@ -76,6 +76,8 @@ header {
   text-decoration: none;
   color: inherit;
   transition: transform 0.2s ease;
+  /* ロゴ(80px)+gap(1rem)分を右に足してサイト名テキストを中央に揃える */
+  padding-right: calc(80px + 1rem);
 }
 
 .logo-section:hover {
@@ -212,6 +214,8 @@ footer {
 @media (max-width: 768px) {
   .logo-section {
     flex-direction: row;
+    /* モバイルはロゴ64px+gap(1rem)分で補正 */
+    padding-right: calc(64px + 1rem);
   }
 
   .logo-image {

--- a/src/routes/about/+page.svelte
+++ b/src/routes/about/+page.svelte
@@ -41,6 +41,10 @@
       </tbody>
     </table>
   </section>
+
+  <div class="back-to-home">
+    <a href="/" class="back-button">TOPページに戻る</a>
+  </div>
 </div>
 
 <style>
@@ -109,6 +113,28 @@
 
   .info-table a:hover {
     text-decoration: underline;
+  }
+
+  .back-to-home {
+    margin-top: 2.5rem;
+    text-align: center;
+  }
+
+  .back-button {
+    display: inline-block;
+    padding: 0.65rem 2rem;
+    border-radius: 999px;
+    background: #fef3c7;
+    color: #92400e;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid #fcd34d;
+    transition: background 0.2s ease;
+  }
+
+  .back-button:hover {
+    background: #fde68a;
   }
 
   @media (max-width: 600px) {

--- a/src/routes/author/editorial-team/+page.svelte
+++ b/src/routes/author/editorial-team/+page.svelte
@@ -18,34 +18,9 @@
     </div>
   </section>
 
-  <section class="section">
-    <h2>運営会社</h2>
-    <table class="info-table">
-      <tbody>
-        <tr>
-          <th>会社名</th>
-          <td>合同会社NBWMedia</td>
-        </tr>
-        <tr>
-          <th>運営メディア</th>
-          <td>脳トレ日和</td>
-        </tr>
-        <tr>
-          <th>所在地</th>
-          <td>東京都中央区銀座1丁目12番4号</td>
-        </tr>
-        <tr>
-          <th>設立</th>
-          <td>2026年4月</td>
-        </tr>
-        <tr>
-          <th>事業内容</th>
-          <td>Webメディア運営・コンテンツ制作</td>
-        </tr>
-      </tbody>
-    </table>
-    <p class="company-link">詳細は<a href="/about">会社概要ページ</a>をご覧ください。</p>
-  </section>
+  <div class="back-to-home">
+    <a href="/" class="back-button">TOPページに戻る</a>
+  </div>
 </div>
 
 <style>
@@ -141,46 +116,26 @@
     margin: 0;
   }
 
-  /* 会社情報テーブル */
-  .info-table {
-    width: 100%;
-    border-collapse: collapse;
-    margin-bottom: 1rem;
+  .back-to-home {
+    margin-top: 2.5rem;
+    text-align: center;
   }
 
-  .info-table th,
-  .info-table td {
-    padding: 0.65rem 1rem;
-    text-align: left;
-    border-bottom: 1px solid #e5e7eb;
+  .back-button {
+    display: inline-block;
+    padding: 0.65rem 2rem;
+    border-radius: 999px;
+    background: #fef3c7;
+    color: #92400e;
     font-size: 0.9rem;
-    vertical-align: top;
-  }
-
-  .info-table th {
-    color: #1f2937;
     font-weight: 600;
-    width: 35%;
-    background: #fafafa;
-  }
-
-  .info-table td {
-    color: #4b5563;
-  }
-
-  .company-link {
-    font-size: 0.9rem;
-    color: #6b7280;
-    margin: 0;
-  }
-
-  .company-link a {
-    color: #d97706;
     text-decoration: none;
+    border: 1px solid #fcd34d;
+    transition: background 0.2s ease;
   }
 
-  .company-link a:hover {
-    text-decoration: underline;
+  .back-button:hover {
+    background: #fde68a;
   }
 
   @media (max-width: 600px) {
@@ -196,16 +151,6 @@
     .author-avatar img {
       width: 44px;
       height: 44px;
-    }
-
-    .info-table th {
-      width: 40%;
-    }
-
-    .info-table th,
-    .info-table td {
-      padding: 0.5rem 0.6rem;
-      font-size: 0.85rem;
     }
   }
 </style>

--- a/src/routes/disclaimer/+page.svelte
+++ b/src/routes/disclaimer/+page.svelte
@@ -56,6 +56,10 @@
     <h2>お問い合わせ</h2>
     <p>免責事項に関するご質問やご意見がございましたら、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
   </section>
+
+  <div class="back-to-home">
+    <a href="/" class="back-button">TOPページに戻る</a>
+  </div>
 </div>
 
 <style>
@@ -169,6 +173,28 @@
 
   .info-table a:hover {
     text-decoration: underline;
+  }
+
+  .back-to-home {
+    margin-top: 2.5rem;
+    text-align: center;
+  }
+
+  .back-button {
+    display: inline-block;
+    padding: 0.65rem 2rem;
+    border-radius: 999px;
+    background: #fef3c7;
+    color: #92400e;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid #fcd34d;
+    transition: background 0.2s ease;
+  }
+
+  .back-button:hover {
+    background: #fde68a;
   }
 
   @media (max-width: 600px) {

--- a/src/routes/privacy-policy/+page.svelte
+++ b/src/routes/privacy-policy/+page.svelte
@@ -105,6 +105,10 @@
     <h2>11. お問い合わせ</h2>
     <p>プライバシーポリシーに関するご質問は、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
   </section>
+
+  <div class="back-to-home">
+    <a href="/" class="back-button">TOPページに戻る</a>
+  </div>
 </div>
 
 <style>
@@ -225,6 +229,28 @@
 
   .info-table a:hover {
     text-decoration: underline;
+  }
+
+  .back-to-home {
+    margin-top: 2.5rem;
+    text-align: center;
+  }
+
+  .back-button {
+    display: inline-block;
+    padding: 0.65rem 2rem;
+    border-radius: 999px;
+    background: #fef3c7;
+    color: #92400e;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid #fcd34d;
+    transition: background 0.2s ease;
+  }
+
+  .back-button:hover {
+    background: #fde68a;
   }
 
   @media (max-width: 600px) {

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -72,6 +72,10 @@
     <h2>第10条（お問い合わせ）</h2>
     <p>本規約に関するお問い合わせは、<a href="/contact">お問い合わせフォーム</a>よりご連絡ください。</p>
   </section>
+
+  <div class="back-to-home">
+    <a href="/" class="back-button">TOPページに戻る</a>
+  </div>
 </div>
 
 <style>
@@ -185,6 +189,28 @@
 
   .info-table a:hover {
     text-decoration: underline;
+  }
+
+  .back-to-home {
+    margin-top: 2.5rem;
+    text-align: center;
+  }
+
+  .back-button {
+    display: inline-block;
+    padding: 0.65rem 2rem;
+    border-radius: 999px;
+    background: #fef3c7;
+    color: #92400e;
+    font-size: 0.9rem;
+    font-weight: 600;
+    text-decoration: none;
+    border: 1px solid #fcd34d;
+    transition: background 0.2s ease;
+  }
+
+  .back-button:hover {
+    background: #fde68a;
   }
 
   @media (max-width: 600px) {


### PR DESCRIPTION
## Summary
- 著者情報ページ（`/author/editorial-team`）から運営会社セクションを削除
- 全固定ページ（会社概要・プライバシーポリシー・利用規約・免責事項・著者情報）にTOPページへ戻るボタンを追加
- ヘッダーの「脳トレ日和」テキストをヘッダー中央に揃える（`padding-right` でロゴ分を補正）

## Test plan
- [ ] 著者情報ページに運営会社テーブルが表示されない
- [ ] 全固定ページ下部に「TOPページに戻る」ボタンが表示される
- [ ] ヘッダーの「脳トレ日和」がスマホ・PCともに中央に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)