### PR TITLE
fix: ボタン全幅化・次の問題へ削除・AdSense余白・サイト名フォント拡大

### DIFF
--- a/src/lib/components/AdSense.svelte
+++ b/src/lib/components/AdSense.svelte
@@ -12,6 +12,8 @@
   let adRef = null;
   /** @type {HTMLDivElement|null} */
   let containerRef = null;
+  /** @type {HTMLDivElement|null} */
+  let sentinelRef = null;
   let currentPath = '';
   /** @type {ReturnType<typeof setInterval>|null} */
   let pollTimer = null;
@@ -24,18 +26,20 @@
     currentPath = $page.url.pathname;
     if (initialized) {
       adPushed = false;
+      // containerを再度非表示に戻してから再観測
+      if (containerRef) containerRef.style.display = 'none';
       observeViewport();
     }
   }
 
   /**
-   * IntersectionObserver でコンテナがビューポートに近づいたらプッシュ。
-   * rootMargin を 400px に拡大してより早めにロードし、
-   * ビューアビリティ率・CPM を向上させる。
+   * センチネル要素（常にDOMに存在、0高さ）をIntersectionObserverで監視。
+   * containerRef（display:none）は非表示のためIO対象にできないため
+   * sentinelRefを代わりに監視する。
    */
   function observeViewport() {
     intersectionObs?.disconnect();
-    if (!containerRef) return;
+    if (!sentinelRef) return;
 
     intersectionObs = new IntersectionObserver(
       (entries) => {
@@ -45,9 +49,9 @@
           intersectionObs?.disconnect();
         }
       },
-      { rootMargin: '400px 0px' } // 200px → 400px に拡大してプリロードを早める
+      { rootMargin: '400px 0px' }
     );
-    intersectionObs.observe(containerRef);
+    intersectionObs.observe(sentinelRef);
   }
 
   function pushAd() {
@@ -79,11 +83,10 @@
     }
   }
 
-  /** 広告確定後にコンテナを表示・最小高さをリセット */
+  /** 広告確定後にコンテナを表示 */
   function reveal() {
     if (containerRef) {
-      containerRef.style.removeProperty('min-height');
-      containerRef.style.removeProperty('visibility');
+      containerRef.style.display = 'block';
     }
   }
 
@@ -120,6 +123,8 @@
   });
 </script>
 
+<!-- sentinelRef: 常にDOMに存在し高さ0。IntersectionObserver用ターゲット -->
+<div bind:this={sentinelRef} style="height:0;overflow:hidden;" aria-hidden="true"></div>
 <div class="adsense-container" bind:this={containerRef}>
   <ins
     bind:this={adRef}
@@ -137,18 +142,13 @@
     position: relative;
     width: 100%;
     max-width: 100%;
-    display: block;
+    /* display:none でスタート → フレックスgapへの影響ゼロ */
+    display: none;
     text-align: center;
-    overflow: visible; /* hidden だと広告左端がクリップされる。親の overflow-x:clip が横スクロールを防ぐ */
+    overflow: visible;
     line-height: 0;
     font-size: 0;
     box-sizing: border-box;
-
-    /*
-     * 広告ロード前は非表示（AdSense側が ins に visibility:visible を設定するまで非表示）
-     * min-height は設定しない：ロード前の不可視空白（レイアウトズレ）を防ぐ
-     */
-    visibility: hidden;
   }
 
   .adsense-container :global(ins.adsbygoogle) {

--- a/src/lib/components/QuizDetailPage.svelte
+++ b/src/lib/components/QuizDetailPage.svelte
@@ -458,7 +458,7 @@
   .hints-toggle .action-button,
   .to-answer .action-button,
   .category-nav .action-button {
-    width: min(100%, 320px);
+    width: 100%;
   }
 
   .action-button {

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -279,7 +279,7 @@
 
   /* ── サイト名フォントサイズ ────────────── */
   :global(.title-section h1) {
-    font-size: clamp(1.45rem, 4.5vw, 2.1rem);
+    font-size: clamp(1.8rem, 5.5vw, 2.6rem);
   }
 
   /* ── ハンバーガーボタン ────────────── */

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -1,52 +1,18 @@
 <script>
-  import { onMount } from 'svelte';
   import RelatedQuizSection from '$lib/components/RelatedQuizSection.svelte';
   import AdSense from '$lib/components/AdSense.svelte';
 
   export let data;
-  const { quiz, nextChallengePosts = [] } = data;
+  const { quiz } = data;
   const relatedQuizzes = Array.isArray(data?.related) ? data.related : [];
   const relatedFallback = quiz?.answerImage?.asset?.url ?? '/logo.svg';
   const closingDefault =
     'このシリーズは毎日更新。明日も新作を公開します。ブックマークしてまた挑戦してください！';
 
-  // 次の問題（スティッキーバー用）
-  const nextPost = nextChallengePosts[0] ?? null;
-  const nextPostHref = nextPost?.slug ? `/quiz/${nextPost.slug}` : null;
-
   // カテゴリリンク
   const categorySlug = quiz?.category?.slug ?? null;
   const categoryTitle = quiz?.category?.title ?? null;
   const categoryHref = categorySlug ? `/category/${categorySlug}` : null;
-
-  // 「さらにもう一問」セクションが画面内に入ったらスティッキーバーを非表示にする
-  let showStickyBar = false;
-  let nextChallengeEl;
-
-  onMount(() => {
-    if (!nextPostHref) return;
-
-    let delayPassed = false;
-    let sectionOffScreen = true; // 初期値: セクションはまだ画面外と仮定
-
-    const update = () => { showStickyBar = delayPassed && sectionOffScreen; };
-
-    const timer = setTimeout(() => {
-      delayPassed = true;
-      update();
-    }, 1200);
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        sectionOffScreen = !entry.isIntersecting;
-        update();
-      },
-      { threshold: 0.2 }
-    );
-    if (nextChallengeEl) observer.observe(nextChallengeEl);
-
-    return () => { clearTimeout(timer); observer.disconnect(); };
-  });
 
   const escapeHtml = (value) =>
     value
@@ -173,7 +139,7 @@
   <AdSense slot="5428887502" />
 
   {#if nextChallengePosts.length > 0}
-    <section class="next-challenge" bind:this={nextChallengeEl}>
+    <section class="next-challenge">
       <h2 class="next-challenge__title">さらにもう一問！</h2>
       <div class="next-challenge__grid">
         {#each nextChallengePosts as post}
@@ -206,13 +172,6 @@
     headingId="related-answer-heading"
   />
 </main>
-
-{#if nextPostHref && showStickyBar}
-  <div class="sticky-next" role="complementary" aria-label="次の問題へ">
-    <span class="sticky-next__label">{nextPost.title}</span>
-    <a class="sticky-next__btn" href={nextPostHref}>次の問題へ <span aria-hidden="true">→</span></a>
-  </div>
-{/if}
 
 <style>
   .answer-page {
@@ -343,7 +302,12 @@
   }
 
   .back-nav {
-    text-align: center;
+    display: flex;
+    justify-content: center;
+  }
+
+  .back-nav .action-button {
+    width: 100%;
   }
 
   .closing {
@@ -467,59 +431,6 @@
     flex-shrink: 0;
   }
 
-  /* ── スティッキー「次の問題へ」バー ───── */
-  :global(.sticky-next) {
-    position: fixed;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    z-index: 200;
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 12px 20px;
-    background: linear-gradient(135deg, #1f2937ee, #111827f5);
-    backdrop-filter: blur(8px);
-    border-top: 1px solid rgba(255, 255, 255, 0.1);
-    animation: slideUp 0.3s ease;
-  }
-
-  :global(.sticky-next__label) {
-    flex: 1;
-    font-size: 0.88rem;
-    color: #fef3c7;
-    font-weight: 600;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    min-width: 0;
-  }
-
-  :global(.sticky-next__btn) {
-    flex-shrink: 0;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    padding: 0.6rem 1.4rem;
-    border-radius: 999px;
-    background: linear-gradient(135deg, #facc15, #f97316);
-    color: #78350f;
-    font-weight: 800;
-    font-size: 0.9rem;
-    text-decoration: none;
-    white-space: nowrap;
-    transition: filter 0.2s ease, transform 0.2s ease;
-  }
-
-  :global(.sticky-next__btn:hover) {
-    filter: brightness(1.08);
-    transform: translateY(-1px);
-  }
-
-  @keyframes slideUp {
-    from { transform: translateY(100%); opacity: 0; }
-    to   { transform: translateY(0);    opacity: 1; }
-  }
 
   @media (max-width: 640px) {
     .answer-page {


### PR DESCRIPTION
## Summary
- 記事内ボタン（ヒントを見る／正解ページへ進む／問題ページに戻る）をコンテンツカードと同じ全幅に統一
- 正解ページ下部のスティッキー「次の問題へ」バーを削除
- AdSense: `display:none` + センチネル方式でロード前のflexガップ余白をゼロに
- ヘッダーの「脳トレ日和」フォントサイズを拡大（`clamp(1.8rem, 5.5vw, 2.6rem)`）

## Test plan
- [ ] 記事ページでヒント・正解ページボタンがカード幅と揃う
- [ ] 正解ページに「次の問題へ」バーが表示されない
- [ ] AdSense広告ロード前の余白がない
- [ ] ヘッダーの「脳トレ日和」が大きく表示される
- [ ] スマホ・タブレット・PC全てで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)