### PR TITLE
fix: AdSense表示復旧・正解ページ修正

### DIFF
--- a/src/lib/components/AdSense.svelte
+++ b/src/lib/components/AdSense.svelte
@@ -24,19 +24,11 @@
     currentPath = $page.url.pathname;
     if (initialized) {
       adPushed = false;
-      // ナビゲーション後は折りたたみ状態に戻してから再観測
-      if (containerRef) {
-        containerRef.style.removeProperty('display');
-        containerRef.classList.remove('revealed');
-      }
+      if (containerRef) containerRef.classList.remove('revealed');
       observeViewport();
     }
   }
 
-  /**
-   * IntersectionObserver でコンテナがビューポートに近づいたらプッシュ。
-   * visibility:hidden なら IO は機能するのでコンテナ自身を観測する。
-   */
   function observeViewport() {
     intersectionObs?.disconnect();
     if (!containerRef) return;
@@ -83,7 +75,6 @@
     }
   }
 
-  /** 広告確定後: 折りたたみ解除して表示 */
   function reveal() {
     if (containerRef) {
       containerRef.classList.add('revealed');
@@ -148,20 +139,16 @@
     box-sizing: border-box;
 
     /*
-     * ロード前: visibility:hidden + overflow:hidden + max-height:0 で
-     * 視覚的に非表示かつ flex gap の影響をゼロにする。
-     * display:block を維持することで Google AdSense が広告を描画できる。
+     * visibility:hidden で非表示スタート。
+     * display:block を維持することで Google が広告を描画できる。
+     * revealed クラス付与時に表示切替。
      */
     visibility: hidden;
-    max-height: 0;
-    overflow: hidden;
   }
 
-  /* 広告ロード完了後に revealed クラスで解放 */
+  /* 広告ロード完了後に表示 */
   .adsense-container.revealed {
     visibility: visible;
-    max-height: none;
-    overflow: visible;
   }
 
   .adsense-container :global(ins.adsbygoogle) {
@@ -170,6 +157,7 @@
     max-width: 100% !important;
   }
 
+  /* unfilled 時は非表示 */
   .adsense-container:has(> ins.adsbygoogle[data-ad-status='unfilled']) {
     display: none !important;
   }


### PR DESCRIPTION
## Summary

- **AdSense復旧**: `display:none` → `visibility:hidden` に変更。Googleが広告を描画できるようにしつつ、ロード前の白紙スペースを非表示にする
- **センチネルdiv削除**: `visibility:hidden` では `containerRef` を直接 `IntersectionObserver` で監視できるため、不要になったセンチネル要素を除去（DOM軽量化）
- **正解ページ修正**: `nextChallengePosts` の destructuring を復元（誤って削除されていたため「さらにもう一問」セクションが表示されない不具合を修正）

## Background

前回PR(#516)で `display:none` ベースの実装に変更したところ：
1. `display:none` コンテナには Google が広告を描画できない → AdSense 非表示
2. センチネルdivに `max-height:0; overflow:hidden` を追加したところ `iframe.offsetHeight` が 0 になり `reveal()` が発火しない問題が発生

最終的に `visibility:hidden` のみで管理するシンプルな実装に落ち着いた。

## Performance notes

- センチネルdiv削除によりDOM要素が1つ減少
- CSS クラストグルによる表示切替（インラインstyle操作より効率的）
- AdSense スクリプト読み込みは `async` のまま変更なし

## Test plan

- [ ] 記事ページを開いてAdSense広告が表示されることを確認
- [ ] 広告が unfilled の場合に余白が消えることを確認（`data-ad-status='unfilled'`）
- [ ] 正解ページで「さらにもう一問！」セクションが表示されることを確認
- [ ] スマホ・タブレット・PCで広告レイアウトが崩れないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)