### PR TITLE
fix: OGP画像をSVG→PNGに変更（Bing検索表示改善）

### DIFF
--- a/src/lib/components/SEO.svelte
+++ b/src/lib/components/SEO.svelte
@@ -31,7 +31,10 @@
 
   $: titleText = title ? `${title} | ${SITE_TITLE}` : SITE_TITLE;
   $: descriptionText = description || SITE_DESCRIPTION;
-  $: imageUrl = image || `${SITE_URL}/logo.svg`;
+  // SVGはBingなど一部クローラーがOGP画像として認識しないためPNGを使用
+  $: imageUrl = image || `${SITE_URL}/logo.png`;
+  $: ogImageWidth = image ? imageWidth : 1024;
+  $: ogImageHeight = image ? imageHeight : 1024;
 
   $: jsonldScript = (() => {
     try {
@@ -108,11 +111,11 @@
   <meta property="og:title" content={titleText} />
   <meta property="og:description" content={descriptionText} />
   <meta property="og:image" content={imageUrl} />
-  {#if imageWidth}
-    <meta property="og:image:width" content={String(imageWidth)} />
+  {#if ogImageWidth}
+    <meta property="og:image:width" content={String(ogImageWidth)} />
   {/if}
-  {#if imageHeight}
-    <meta property="og:image:height" content={String(imageHeight)} />
+  {#if ogImageHeight}
+    <meta property="og:image:height" content={String(ogImageHeight)} />
   {/if}
   <meta property="og:image:alt" content={titleText} />
   <meta property="og:site_name" content={SITE_TITLE} />


### PR DESCRIPTION
## Summary

- `og:image` のデフォルト画像を `logo.svg` → `logo.png`（1024×1024）に変更
- `og:image:width` / `og:image:height` をデフォルト値でも明示出力するよう修正

## Background

Bingの検索結果でサイトロゴではなく記事の画像（読解クイズ画像）が表示されていた。
原因：SVG形式はBingを含む一部クローラーがOGP画像として認識しないため、ページ内の別の画像を拾ってしまう。

`static/logo.png`（1024×1024 PNG）が既に存在するためこれを使用。

## Test plan

- [ ] トップページのHTMLソースで `og:image` が `/logo.png` になっていることを確認
- [ ] 記事ページでは従来通り記事のOGP画像が使われることを確認
- [ ] [OGP確認ツール](https://developers.facebook.com/tools/debug/) でロゴが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)