### PR TITLE
fix: snf:advertisement内のsponsoredLinkインデントを修正

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -164,7 +164,7 @@ export async function GET() {
 					const title = escapeXml(quiz.title);
 					return `<snf:sponsoredLink link="${link}" thumbnail="${thumbnailUrl}" title="${title}" advertiser="${siteTitle}"/>`;
 				})
-				.join('\n\t\t\t');
+				.join('\n\t\t\t\t');
 
 			const advertisementXml = advertisementLinks
 				? `


### PR DESCRIPTION
## Summary
- SmartNews RSSフィード（`/feed/smartnews`）の `<snf:advertisement>` 内で、2件目以降の `<snf:sponsoredLink>` のインデントがずれていた問題を修正
- `.join('\n\t\t\t')` → `.join('\n\t\t\t\t')` に変更し、全要素のインデントを統一

## Before
```xml
<snf:advertisement>
    <snf:sponsoredLink ... />
<snf:sponsoredLink ... />   ← インデントがずれていた
</snf:advertisement>
```

## After
```xml
<snf:advertisement>
    <snf:sponsoredLink ... />
    <snf:sponsoredLink ... />   ← 揃った
</snf:advertisement>
```

## Test plan
- [ ] `/feed/smartnews` を取得し、`<snf:advertisement>` 内の全 `<snf:sponsoredLink>` のインデントが揃っていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)