### PR TITLE
fix: SmartFormatチェックツールのWARNINGを解消

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -218,6 +218,9 @@ export async function GET() {
 			<category>${escapeXml(article.category?.title || article.category?.name || 'クイズ')}</category>
 			${advertisementXml}
 			${relatedLinksXml}
+			<snf:analytics>
+				<snf:AnalyticsCode type="GoogleAnalytics4">G-855Y7S6M95</snf:AnalyticsCode>
+			</snf:analytics>
 		</item>
 		`.trim();
 		};
@@ -242,7 +245,7 @@ export async function GET() {
 	<snf:logo>
 		<url>${siteLogo}</url>
 	</snf:logo>
-	<ttl>60</ttl>
+	<ttl>15</ttl>
 	${items}
 </channel>
 </rss>`.trim();


### PR DESCRIPTION
## Summary
SmartFormatチェックツールで検出された2件のWARNINGを修正。

- `channel.ttl` を `60` → `15` に変更（推奨値は1〜15）
- 全itemに `<snf:analytics>` タグを追加（GA4トラッキングID: G-855Y7S6M95）

## Test plan
- [ ] `/feed/smartnews` をSmartFormatチェックツールに通してWARNINGが消えることを確認
- [ ] フィードが正常に返ること（200 OK）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)