### PR TITLE
fix: snf:analyticsをCDATAセクションで囲む

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -218,9 +218,7 @@ export async function GET() {
 			<category>${escapeXml(article.category?.title || article.category?.name || 'クイズ')}</category>
 			${advertisementXml}
 			${relatedLinksXml}
-			<snf:analytics>
-				<snf:AnalyticsCode type="GoogleAnalytics4">G-855Y7S6M95</snf:AnalyticsCode>
-			</snf:analytics>
+			<snf:analytics><![CDATA[<snf:AnalyticsCode type="GoogleAnalytics4">G-855Y7S6M95</snf:AnalyticsCode>]]></snf:analytics>
 		</item>
 		`.trim();
 		};


### PR DESCRIPTION
## Summary
SmartFormatチェックツールで「item.snf:analytics は CDATA セクションにしてください」エラーが出たため修正。

**Before:**
\`\`\`xml
<snf:analytics>
    <snf:AnalyticsCode type="GoogleAnalytics4">G-855Y7S6M95</snf:AnalyticsCode>
</snf:analytics>
\`\`\`

**After:**
\`\`\`xml
<snf:analytics><![CDATA[<snf:AnalyticsCode type="GoogleAnalytics4">G-855Y7S6M95</snf:AnalyticsCode>]]></snf:analytics>
\`\`\`

## Test plan
- [ ] `/feed/smartnews` をSmartFormatチェックツールに通してエラーが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)