### PR TITLE
fix: snf:analyticsのtype属性をGoogleAnalyticsに修正

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -218,7 +218,7 @@ export async function GET() {
 			<category>${escapeXml(article.category?.title || article.category?.name || 'クイズ')}</category>
 			${advertisementXml}
 			${relatedLinksXml}
-			<snf:analytics><![CDATA[<snf:AnalyticsCode type="GoogleAnalytics4">G-855Y7S6M95</snf:AnalyticsCode>]]></snf:analytics>
+			<snf:analytics><![CDATA[<snf:AnalyticsCode type="GoogleAnalytics">G-855Y7S6M95</snf:AnalyticsCode>]]></snf:analytics>
 		</item>
 		`.trim();
 		};


### PR DESCRIPTION
## Summary
SmartFormatチェックツールで「item.snf:analytics の内容を確認してください」エラーが出たため修正。

SmartNews SmartFormatが認識する `type` 属性値は `GoogleAnalytics` のみで、`GoogleAnalytics4` は未対応のため変更。

**Before:** `type="GoogleAnalytics4"`
**After:** `type="GoogleAnalytics"`

## Test plan
- [ ] `/feed/smartnews` をSmartFormatチェックツールに通してエラーが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)