### PR TITLE
fix: GA4非対応のsnf:analyticsタグを削除

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -218,7 +218,6 @@ export async function GET() {
 			<category>${escapeXml(article.category?.title || article.category?.name || 'クイズ')}</category>
 			${advertisementXml}
 			${relatedLinksXml}
-			<snf:analytics><![CDATA[<snf:AnalyticsCode type="GoogleAnalytics">G-855Y7S6M95</snf:AnalyticsCode>]]></snf:analytics>
 		</item>
 		`.trim();
 		};


### PR DESCRIPTION
## Summary
SmartFormatチェックツールで「item.snf:analytics の内容を確認してください」エラーが解消できないため、`snf:analytics` タグを削除。

## 原因
SmartNews SmartFormatの `snf:analytics` タグは Universal Analytics（UA-XXXXXXXX-X）にのみ対応しており、GA4（G-XXXXXXXX）のIDは未対応。type属性の変更（`GoogleAnalytics4` → `GoogleAnalytics`）でも解消しなかった。

## 影響範囲
- コンテンツ掲載・配信：影響なし
- SmartView（SmartNewsアプリ内トラフィック）のGA4への反映：非対応のまま（元々動作していなかった）

## Test plan
- [ ] `/feed/smartnews` をSmartFormatチェックツールに通してエラーが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)