### PR TITLE
feat: add snf:analytics tag with GA4 gtag.js to SmartNews RSS feed

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -218,6 +218,7 @@ export async function GET() {
 			<category>${escapeXml(article.category?.title || article.category?.name || 'クイズ')}</category>
 			${advertisementXml}
 			${relatedLinksXml}
+			<snf:analytics><![CDATA[<script async src="https://www.googletagmanager.com/gtag/js?id=G-855Y7S6M95"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-855Y7S6M95');</script>]]></snf:analytics>
 		</item>
 		`.trim();
 		};


### PR DESCRIPTION
## Summary
- SmartFormat チェックツールの「item.snf:analytics のご指定を推奨しております」WARNING を解消
- 各 `<item>` に GA4 追跡スクリプト（G-855Y7S6M95）を `<snf:analytics>` の CDATA セクションとして埋め込み

## Test plan
- [ ] デプロイ後、https://noutorebiyori.com/feed/smartnews を SmartFormat チェックツールで再検証
- [ ] `item.snf:analytics` の WARNING が解消されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)