### PR TITLE
fix: merge snf:analytics into single script tag per SmartFormat spec

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -218,7 +218,7 @@ export async function GET() {
 			<category>${escapeXml(article.category?.title || article.category?.name || 'クイズ')}</category>
 			${advertisementXml}
 			${relatedLinksXml}
-			<snf:analytics><![CDATA[<script async src="https://www.googletagmanager.com/gtag/js?id=G-855Y7S6M95"></script><script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-855Y7S6M95');</script>]]></snf:analytics>
+			<snf:analytics><![CDATA[<script>(function(){var s=document.createElement('script');s.async=true;s.src='https://www.googletagmanager.com/gtag/js?id=G-855Y7S6M95';document.head.appendChild(s);window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-855Y7S6M95');})();</script>]]></snf:analytics>
 		</item>
 		`.trim();
 		};


### PR DESCRIPTION
## Summary
- SmartFormat 仕様の「`<snf:analytics>` 内の script タグは1つだけ」要件に対応
- 外部ローダー（`<script async src="...">）とインライン設定の2タグを、動的に gtag.js をロードする1つの inline script に統合

## Before
```xml
<snf:analytics><![CDATA[
  <script async src="https://www.googletagmanager.com/gtag/js?id=G-855Y7S6M95"></script>
  <script>window.dataLayer=...gtag('config','G-855Y7S6M95');</script>
]]></snf:analytics>
```

## After
```xml
<snf:analytics><![CDATA[
  <script>(function(){var s=document.createElement('script');s.async=true;s.src='https://...gtag.js?id=G-855Y7S6M95';document.head.appendChild(s);...gtag('config','G-855Y7S6M95');})();</script>
]]></snf:analytics>
```

## Test plan
- [ ] マージ・デプロイ後、SmartFormat チェックツールで `item.snf:analytics` WARNING が解消されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)