### PR TITLE
Use semantic HTML for site title based on page location

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -178,7 +178,11 @@
           fetchpriority="high"
         />
         <div class="title-section">
-          <h1>脳トレ日和</h1>
+          {#if $page.url.pathname === '/'}
+            <h1 class="site-title-text">脳トレ日和</h1>
+          {:else}
+            <span class="site-title-text">脳トレ日和</span>
+          {/if}
         </div>
       </a>
       <button
@@ -310,8 +314,11 @@
   }
 
   /* ── サイト名フォントサイズ ────────────── */
-  :global(.title-section h1) {
+  :global(.title-section .site-title-text) {
+    display: block;
     font-size: clamp(1.8rem, 5.5vw, 2.6rem);
+    font-weight: 800;
+    margin: 0;
   }
 
   /* ── ハンバーガーボタン ────────────── */


### PR DESCRIPTION
## Summary
Updated the site title markup to use semantic HTML elements based on the current page location, improving accessibility and SEO while maintaining consistent styling.

## Key Changes
- Modified the site title in the header to render as an `<h1>` element only on the homepage (`/`), and as a `<span>` on all other pages
- Consolidated CSS styling under a new `.site-title-text` class that applies to both elements
- Added explicit CSS properties (`display: block`, `font-weight: 800`, `margin: 0`) to ensure consistent appearance across both element types

## Implementation Details
- Used Svelte's conditional rendering (`{#if}`) to determine which element to render based on `$page.url.pathname`
- The `<h1>` on the homepage improves SEO and provides proper document structure
- The `<span>` on other pages prevents multiple `<h1>` elements on the page, which is a semantic HTML best practice
- CSS styling remains visually identical through the shared `.site-title-text` class with explicit display and margin properties

https://claude.ai/code/session_015sZusqWxF88zoz6NrxSEEn