### PR TITLE
fix: Sanity Studioスマホ一覧フリーズを解消（旧画像フェッチ削除）

### DIFF
--- a/studio/schemas/quiz.js
+++ b/studio/schemas/quiz.js
@@ -401,19 +401,16 @@ export default defineType({
     select: {
       title: 'title',
       media: 'problemImage',
-      fallbackMedia: 'questionImage',
       publishedAt: 'publishedAt',
       slug: 'slug.current'
     },
-    prepare({title, media, fallbackMedia, publishedAt, slug}) {
+    prepare({title, media, publishedAt, slug}) {
       const safeTitle =
         typeof title === 'string' && title.trim().length > 0
           ? title
           : '（無題のクイズ）'
 
-      const primaryMedia = media?.asset?._ref ? media : undefined
-      const legacyMedia = fallbackMedia?.asset?._ref ? fallbackMedia : undefined
-      const safeMedia = primaryMedia ?? legacyMedia
+      const safeMedia = media?.asset?._ref ? media : undefined
 
       let dateLabel = '公開日未設定'
       if (publishedAt) {


### PR DESCRIPTION
## 原因

`studio/schemas/quiz.js` のプレビュー設定で、クイズ一覧を開くたびに**全ドキュメントに対して画像を2枚分**フェッチしていた。

```js
// 修正前
select: {
  media: 'problemImage',
  fallbackMedia: 'questionImage',  // ← レガシーフィールドだが全件取得していた
}
```

Sanity Studioの一覧画面はすべての表示件数の `select` フィールドをGROQでまとめて取得するため、`problemImage`（現行）と `questionImage`（旧・移行済み）の2枚分 = **画像リクエストが約2倍**になっていた。スマホはPCより帯域・メモリが少ないため、これが蓄積してフリーズを引き起こしていた。

## 修正内容

`fallbackMedia: 'questionImage'` を削除し、`problemImage` のみに統一。

`questionImage` はすでにレガシー扱い（`readOnly: true` / `hidden: true`）で移行完了済みのため影響なし。

## 確認方法

マージ後に `sanity deploy` でStudioをデプロイし、スマホのクイズ一覧画面でフリーズが解消されているか確認してください。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ruy99YJMVfz4JQsZm9SovL)_