### PR TITLE
fix: Sanity Studioモバイルスクロール不可・フリーズを解消

### DIFF
--- a/studio/components/MobileScrollFix.js
+++ b/studio/components/MobileScrollFix.js
@@ -8,7 +8,8 @@ const CSS = `
   }
 `
 
-export function MobileScrollFix({renderDefault}) {
+export function MobileScrollFix(props) {
+  const {renderDefault} = props
   React.useEffect(() => {
     const style = document.createElement('style')
     style.id = 'mobile-scroll-fix'
@@ -20,5 +21,5 @@ export function MobileScrollFix({renderDefault}) {
     }
   }, [])
 
-  return renderDefault({})
+  return renderDefault(props)
 }

--- a/studio/components/MobileScrollFix.js
+++ b/studio/components/MobileScrollFix.js
@@ -1,0 +1,24 @@
+import React from 'react'
+
+const CSS = `
+  /* モバイルChromeでドキュメントリストペインがスクロールできない問題の修正 */
+  [data-testid="pane-content"] {
+    -webkit-overflow-scrolling: touch;
+    touch-action: pan-y;
+  }
+`
+
+export function MobileScrollFix({renderDefault}) {
+  React.useEffect(() => {
+    const style = document.createElement('style')
+    style.id = 'mobile-scroll-fix'
+    style.textContent = CSS
+    document.head.appendChild(style)
+    return () => {
+      const el = document.getElementById('mobile-scroll-fix')
+      if (el) el.remove()
+    }
+  }, [])
+
+  return renderDefault({})
+}

--- a/studio/sanity.config.js
+++ b/studio/sanity.config.js
@@ -4,6 +4,7 @@ import {visionTool} from '@sanity/vision'
 
 import {deskStructure} from './structure/index.js'
 import {schemaTypes} from './schemas'
+import {MobileScrollFix} from './components/MobileScrollFix.js'
 
 const projectId = process.env.SANITY_STUDIO_PROJECT_ID ?? 'quljge22'
 const dataset = process.env.SANITY_STUDIO_DATASET ?? 'production'
@@ -21,6 +22,11 @@ export default defineConfig({
       structure: (S) => deskStructure(S)
     })
   ],
+  studio: {
+    components: {
+      layout: MobileScrollFix
+    }
+  },
   schema: {
     types: schemaTypes
   }

--- a/studio/schemas/quiz.js
+++ b/studio/schemas/quiz.js
@@ -401,19 +401,16 @@ export default defineType({
     select: {
       title: 'title',
       media: 'problemImage',
-      fallbackMedia: 'questionImage',
       publishedAt: 'publishedAt',
       slug: 'slug.current'
     },
-    prepare({title, media, fallbackMedia, publishedAt, slug}) {
+    prepare({title, media, publishedAt, slug}) {
       const safeTitle =
         typeof title === 'string' && title.trim().length > 0
           ? title
           : '（無題のクイズ）'
 
-      const primaryMedia = media?.asset?._ref ? media : undefined
-      const legacyMedia = fallbackMedia?.asset?._ref ? fallbackMedia : undefined
-      const safeMedia = primaryMedia ?? legacyMedia
+      const safeMedia = media?.asset?._ref ? media : undefined
 
       let dateLabel = '公開日未設定'
       if (publishedAt) {

--- a/studio/schemas/quiz.js
+++ b/studio/schemas/quiz.js
@@ -1,5 +1,6 @@
 // studio/schemas/quiz.js
 import {defineArrayMember, defineField, defineType} from 'sanity'
+import {QuizIcon} from '../icons.js'
 
 export default defineType({
   name: 'quiz',
@@ -400,17 +401,14 @@ export default defineType({
   preview: {
     select: {
       title: 'title',
-      media: 'problemImage',
       publishedAt: 'publishedAt',
       slug: 'slug.current'
     },
-    prepare({title, media, publishedAt, slug}) {
+    prepare({title, publishedAt, slug}) {
       const safeTitle =
         typeof title === 'string' && title.trim().length > 0
           ? title
           : '（無題のクイズ）'
-
-      const safeMedia = media?.asset?._ref ? media : undefined
 
       let dateLabel = '公開日未設定'
       if (publishedAt) {
@@ -429,7 +427,7 @@ export default defineType({
       return {
         title: safeTitle,
         subtitle,
-        media: safeMedia
+        media: QuizIcon
       }
     }
   }


### PR DESCRIPTION
## 対応内容

スマホ（Chrome）でクイズ一覧画面がスクロールできない・フリーズする問題を3段階で修正。

### 1. プレビューの旧画像フェッチを削除
`preview.select` から `fallbackMedia: 'questionImage'` を削除。`questionImage` は移行済みのレガシーフィールドのため不要。

### 2. 一覧のサムネイル画像フェッチを完全削除
`preview.select` から `media: 'problemImage'` も削除し、静的アイコン（🧠）に置き換え。一覧表示時の画像ネットワークリクエストをゼロにする。

### 3. モバイルタッチスクロール修正（CSS injection）
記事入稿画面はスクロール可能であることから、ドキュメントリストペイン固有のタッチイベント処理が原因と特定。`studio.components.layout` に `MobileScrollFix` コンポーネントを登録し、`[data-testid="pane-content"]` に `touch-action: pan-y` を適用。

## 確認方法

マージ後に `cd studio && pnpm deploy` でデプロイし、スマホのクイズ一覧画面でスクロールできるか確認してください。

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ruy99YJMVfz4JQsZm9SovL)_