### PR TITLE
fix: TRILLフィード — Vercel Node.jsランタイム指定を追加（記事0件バグ修正）

### DIFF
--- a/src/routes/feed/trill/+server.ts
+++ b/src/routes/feed/trill/+server.ts
@@ -1,6 +1,9 @@
 // src/routes/feed/trill/+server.ts
 import type { RequestHandler } from './$types';
 import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
+
+export const prerender = false;
+export const config = { runtime: 'nodejs22.x' };
 import { getAbsoluteUrl } from '$lib/rss/getAbsoluteUrl';
 import { buildImageUrl } from '$lib/rss/images';
 import { toRfc822 } from '$lib/rss/toRfc822';


### PR DESCRIPTION
## 原因

`sanity.server.js` は Node.js 専用モジュール（`$env/dynamic/private` 等）を使用しているため、Vercel の edge ランタイムでは動作しません。その結果、Sanity からデータを取得できず、フィードが空になっていました。

## 修正内容

`src/routes/feed/trill/+server.ts` に以下を追加：

```ts
export const prerender = false;
export const config = { runtime: 'nodejs22.x' };
```

同じ問題を持っていた `src/routes/rss/merkystyle.xml/+server.ts` と同等の設定にします。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_