### PR TITLE
fix: TRILLフィード GROQのdateTime()ラッパー削除（記事0件バグ修正）

### DIFF
--- a/src/lib/queries/rssTrill.groq.js
+++ b/src/lib/queries/rssTrill.groq.js
@@ -1,6 +1,6 @@
 // src/lib/queries/rssTrill.groq.js
 
-const PUBLISHED_DATETIME_FIELD = 'dateTime(coalesce(publishedAt, _createdAt))';
+const PUBLISHED_DATETIME_FIELD = 'coalesce(publishedAt, _createdAt)';
 
 const PUBLISHED_FILTER = `
   defined(slug.current) &&

--- a/src/routes/feed/trill/+server.ts
+++ b/src/routes/feed/trill/+server.ts
@@ -1,6 +1,9 @@
 // src/routes/feed/trill/+server.ts
 import type { RequestHandler } from './$types';
 import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
+
+export const prerender = false;
+export const config = { runtime: 'nodejs22.x' };
 import { getAbsoluteUrl } from '$lib/rss/getAbsoluteUrl';
 import { buildImageUrl } from '$lib/rss/images';
 import { toRfc822 } from '$lib/rss/toRfc822';


### PR DESCRIPTION
## 原因

`publishedAt` / `_createdAt` は Sanity 内部で既に Datetime 型として保存されているため、`dateTime()` でラップすると GROQ エラーが発生し、フィルターが全件を除外（または例外をスロー）して 0 件を返していました。

## 修正

```groq
// Before（エラー）
dateTime(coalesce(publishedAt, _createdAt)) <= now()

// After（正常）
coalesce(publishedAt, _createdAt) <= now()
```

`quizVisibility.js` や `rssMerkystyle.groq.js` と同じ書き方に統一しました。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_