### PR TITLE
fix: TRILLフィード metadataネストプロジェクション削除（パースエラー根治）

### DIFF
--- a/src/lib/queries/rssTrill.groq.js
+++ b/src/lib/queries/rssTrill.groq.js
@@ -39,7 +39,7 @@ export const RSS_TRILL_QUERY = /* groq */ `
       url,
       mimeType,
       extension,
-      metadata{ dimensions{ width, height } }
+      metadata
     }
   },
 
@@ -50,7 +50,7 @@ export const RSS_TRILL_QUERY = /* groq */ `
       url,
       mimeType,
       extension,
-      metadata{ dimensions{ width, height } }
+      metadata
     }
   },
 
@@ -61,7 +61,7 @@ export const RSS_TRILL_QUERY = /* groq */ `
       url,
       mimeType,
       extension,
-      metadata{ dimensions{ width, height } }
+      metadata
     }
   },
 
@@ -88,7 +88,7 @@ export const RSS_TRILL_QUERY = /* groq */ `
           url,
           mimeType,
           extension,
-          metadata{ dimensions{ width, height } }
+          metadata
         }
       }
     }


### PR DESCRIPTION
## 根本原因

GROQ パースエラー `expected '}' following object body` の原因は、`metadata{ dimensions{ width, height } }` という**二重ネストのインラインプロジェクション**でした。

動作している `src/routes/quiz/[...slug]/+page.server.js`（クイズページ）のクエリは `asset->{ url, metadata }` のように `metadata` をオブジェクト全体で取得しており、二重ネストを使っていません。

## 修正

```groq
// Before（パースエラー）
asset->{ ..., metadata{ dimensions{ width, height } } }

// After（動作確認済みパターン）
asset->{ ..., metadata }
```

`dimensions` は JS 側（`renderTrillFigure`）で `source.asset.metadata.dimensions.width/height` として参照するため、取得データに不足はありません。

## 補足

`select(){}` 構文自体は有効（クイズページでも使用）でした。問題は metadata の二重ネストのみ。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_