### PR TITLE
fix: TRILLフィード related三項演算子をselect()化（パースエラー根治）

### DIFF
--- a/src/lib/queries/rssTrill.groq.js
+++ b/src/lib/queries/rssTrill.groq.js
@@ -67,8 +67,8 @@ export const RSS_TRILL_QUERY = /* groq */ `
 
   "category": category->{ _id, title, name },
 
-  "related": defined(category._ref) ? (
-    *[
+  "related": select(
+    defined(category._ref) => *[
       _type == "quiz" &&
       ${PUBLISHED_FILTER} &&
       references(^.category._ref) &&
@@ -91,7 +91,8 @@ export const RSS_TRILL_QUERY = /* groq */ `
           metadata
         }
       }
-    }
-  ) : []
+    },
+    []
+  )
 }
 `;


### PR DESCRIPTION
## 根本原因（確定）

前回の修正で metadata 二重ネストは解消され、エラー位置が `related` フィールドまで前進しました。真の原因は：

**GROQ は C 言語スタイルの三項演算子 `? :` をサポートしていません。**

```groq
// NG（パースエラー: expected '}' following object body）
"related": defined(category._ref) ? (...) : []

// OK
"related": select(defined(category._ref) => (...), [])
```

動作している `quiz/[...slug]/+page.server.js` のクエリには `? :` が一切使われていません。

## 修正

`related` の三項演算子を `select()` に置換しました。これで全フィールドが GROQ 仕様準拠になります。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_