### PR TITLE
fix: TRILLフィード dateTime()削除で実行時0件を解消

### DIFF
--- a/src/lib/queries/rssTrill.groq.js
+++ b/src/lib/queries/rssTrill.groq.js
@@ -1,7 +1,7 @@
 // src/lib/queries/rssTrill.groq.js
 // rssMerkystyle.groq.js と同じ構造で記述（動作確認済み構文を踏襲）
 
-const PUBLISHED_DATETIME_FIELD = 'dateTime(coalesce(publishedAt, _createdAt))';
+const PUBLISHED_DATETIME_FIELD = 'coalesce(publishedAt, _createdAt)';
 
 const PUBLISHED_FILTER = `
   defined(slug.current) &&

--- a/src/routes/feed/trill/+server.ts
+++ b/src/routes/feed/trill/+server.ts
@@ -369,14 +369,13 @@ const buildItemXml = (item: NonNullable<ReturnType<typeof toItem>>): string => {
 const buildFeed = (docs: any[], debugError?: string): string => {
 	const now = toRfc822(new Date());
 	const feedUrl = `${SITE_URL}${FEED_PATH}`;
-	const itemsXml = docs
-		.map(toItem)
-		.filter(Boolean)
-		.map((item) => buildItemXml(item!))
-		.join('\n');
+	const items = docs.map(toItem).filter(Boolean);
+	const itemsXml = items.map((item) => buildItemXml(item!)).join('\n');
 	const desc = debugError
 		? `[DEBUG ERROR] ${debugError}`
-		: CHANNEL.description;
+		: items.length === 0
+			? `[DEBUG] docs=${docs.length} items=${items.length}`
+			: CHANNEL.description;
 
 	return [
 		'<?xml version="1.0" encoding="UTF-8"?>',


### PR DESCRIPTION
## 進捗

前回までで GROQ パースエラーは完全に解消（`[DEBUG ERROR]` が消えた）。今回は**実行時に 0 件**返る問題に対応します。

## 原因

`publishedAt` は既に Sanity の datetime 型のため、`dateTime()` でラップすると null になり、フィルター `null <= now()` が全件 false になって全除外されていました。

```groq
// Before（全件除外）
dateTime(coalesce(publishedAt, _createdAt)) <= now()

// After（動作するquizページと同じ）
coalesce(publishedAt, _createdAt) <= now()
```

## デバッグ補助

0 件時に `<description>` へ `[DEBUG] docs=N items=M` を出力。これで「クエリが 0 件」か「toItem で除外」かを切り分け可能。確認後に削除します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_