### PR TITLE
chore: TRILLフィードのデバッグ出力を削除（本番クリーンアップ）

### DIFF
--- a/src/routes/feed/trill/+server.ts
+++ b/src/routes/feed/trill/+server.ts
@@ -366,16 +366,14 @@ const buildItemXml = (item: NonNullable<ReturnType<typeof toItem>>): string => {
 	return lines.join('\n');
 };
 
-const buildFeed = (docs: any[], debugError?: string): string => {
+const buildFeed = (docs: any[]): string => {
 	const now = toRfc822(new Date());
 	const feedUrl = `${SITE_URL}${FEED_PATH}`;
-	const items = docs.map(toItem).filter(Boolean);
-	const itemsXml = items.map((item) => buildItemXml(item!)).join('\n');
-	const desc = debugError
-		? `[DEBUG ERROR] ${debugError}`
-		: items.length === 0
-			? `[DEBUG] docs=${docs.length} items=${items.length}`
-			: CHANNEL.description;
+	const itemsXml = docs
+		.map(toItem)
+		.filter(Boolean)
+		.map((item) => buildItemXml(item!))
+		.join('\n');
 
 	return [
 		'<?xml version="1.0" encoding="UTF-8"?>',
@@ -386,7 +384,7 @@ const buildFeed = (docs: any[], debugError?: string): string => {
 		'<channel>',
 		`  <title>${escapeXml(CHANNEL.title)}</title>`,
 		`  <link>${escapeXml(CHANNEL.link)}</link>`,
-		`  <description>${escapeXml(desc)}</description>`,
+		`  <description>${escapeXml(CHANNEL.description)}</description>`,
 		`  <language>${escapeXml(CHANNEL.language)}</language>`,
 		`  <pubDate>${escapeXml(now)}</pubDate>`,
 		`  <lastBuildDate>${escapeXml(now)}</lastBuildDate>`,
@@ -409,9 +407,8 @@ export const GET: RequestHandler = async ({ setHeaders }) => {
 		const feed = buildFeed(Array.isArray(docs) ? docs : []);
 		return new Response(feed, { status: 200, headers });
 	} catch (err: any) {
-		const msg = err?.message ?? String(err);
-		console.error('[feed/trill] fetch error:', msg);
-		return new Response(buildFeed([], msg), {
+		console.error('[feed/trill] fetch error:', err?.message ?? String(err));
+		return new Response(buildFeed([]), {
 			status: 503,
 			headers: { 'Content-Type': 'application/xml; charset=utf-8', 'Cache-Control': 'no-store' }
 		});


### PR DESCRIPTION
## 概要

TRILL フィードが本番で全記事を正常配信できることを確認したため、デバッグ用コードを削除します。

## 削除内容

- `<description>` への `[DEBUG ERROR] ...` 出力
- 0件時の `[DEBUG] docs=N items=M` 出力
- `buildFeed` の `debugError` 引数

エラー時は引き続き `console.error` でログ出力 + 503 + `no-store` を返します。

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_