### PR TITLE
fix(merkystyle): Merkystyleフィード 記事0件バグを修正

### DIFF
--- a/src/lib/queries/rssMerkystyle.groq.js
+++ b/src/lib/queries/rssMerkystyle.groq.js
@@ -1,6 +1,6 @@
 // src/lib/queries/rssMerkystyle.groq.js
 
-const PUBLISHED_DATETIME_FIELD = 'dateTime(coalesce(publishedAt, _createdAt))';
+const PUBLISHED_DATETIME_FIELD = 'coalesce(publishedAt, _createdAt)';
 
 // 公開判定（ドラフト除外＆公開日時チェック）
 const PUBLISHED_FILTER = `
@@ -30,7 +30,7 @@ export const RSS_MERKYSTYLE_QUERY = /* groq */ `
       url,
       mimeType,
       extension,
-      metadata{ dimensions{ width, height } }
+      metadata
     }
   },
 
@@ -41,7 +41,7 @@ export const RSS_MERKYSTYLE_QUERY = /* groq */ `
       url,
       mimeType,
       extension,
-      metadata{ dimensions{ width, height } }
+      metadata
     }
   },
 
@@ -52,19 +52,19 @@ export const RSS_MERKYSTYLE_QUERY = /* groq */ `
       url,
       mimeType,
       extension,
-      metadata{ dimensions{ width, height } }
+      metadata
     }
   },
 
   thumbnailUrl,
 
   // ==== 関連クイズ ====
-  "related": defined(category._ref) ? (
-    *[
+  "related": select(
+    defined(category._ref) => *[
       _type == "quiz" &&
       ${PUBLISHED_FILTER} &&
       references(^.category._ref) &&
-      slug.current != ^.slug
+      slug.current != ^.slug.current
     ]
     | order(${PUBLISHED_DATETIME_FIELD} desc)[0...3]{
       title,
@@ -81,11 +81,12 @@ export const RSS_MERKYSTYLE_QUERY = /* groq */ `
           url,
           mimeType,
           extension,
-          metadata{ dimensions{ width, height } }
+          metadata
         }
       },
       thumbnailUrl
-    }
-  ) : []
+    },
+    []
+  )
 }
 `;

--- a/src/routes/rss/merkystyle.xml/+server.ts
+++ b/src/routes/rss/merkystyle.xml/+server.ts
@@ -1,12 +1,21 @@
 // src/routes/rss/merkystyle.xml/+server.ts
 import type { RequestHandler } from './$types';
-import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
+import { createClient } from '@sanity/client';
+import { shouldSkipSanityFetch } from '$lib/sanity.server.js';
+import { SANITY_DEFAULTS } from '$lib/sanityDefaults.js';
 import { getAbsoluteUrl } from '$lib/rss/getAbsoluteUrl';
 import { portableTextToHtml, portableTextToPlain } from '$lib/rss/portableText';
 import { resolveImage } from '$lib/rss/images';
 import { toRfc822 } from '$lib/rss/toRfc822';
 import { resolvePublishedDate } from '$lib/queries/quizVisibility.js';
 import { RSS_MERKYSTYLE_QUERY } from '$lib/queries/rssMerkystyle.groq.js';
+
+const sanityClient = createClient({
+  projectId: import.meta.env?.VITE_SANITY_PROJECT_ID || SANITY_DEFAULTS.projectId,
+  dataset: import.meta.env?.VITE_SANITY_DATASET || SANITY_DEFAULTS.dataset,
+  apiVersion: import.meta.env?.VITE_SANITY_API_VERSION || SANITY_DEFAULTS.apiVersion,
+  useCdn: false
+});
 
 export const prerender = false;
 export const config = { runtime: 'nodejs22.x' };
@@ -304,7 +313,7 @@ export const GET: RequestHandler = async ({ setHeaders }) => {
 
   try {
     console.log('[rss] groq >>\n', RSS_MERKYSTYLE_QUERY);
-    const docs: any[] = await client.fetch(RSS_MERKYSTYLE_QUERY);
+    const docs: any[] = await sanityClient.fetch(RSS_MERKYSTYLE_QUERY);
     console.log('[rss] fetched docs:', docs.length);
     const items = Array.isArray(docs) ? docs.map(toItem).filter(Boolean).slice(0, 30) : [];
     console.info('[rss] converted items:', items?.length ?? 0);
@@ -315,7 +324,7 @@ export const GET: RequestHandler = async ({ setHeaders }) => {
     const fallbackFeed = buildFeed([]);
     return new Response(fallbackFeed, {
       status: 503,
-      headers
+      headers: { 'Content-Type': 'application/xml; charset=utf-8', 'Cache-Control': 'no-store' }
     });
   }
 };


### PR DESCRIPTION
## 概要

`/rss/merkystyle.xml` で記事が1件も取得できない問題を修正します。

## 修正内容

### `rssMerkystyle.groq.js`
- `dateTime(coalesce(...))` → `coalesce(...)` に変更（`dateTime()` ラッパーが datetime 型フィールドに null を返し、全記事が公開フィルターで除外）
- `metadata{ dimensions{ width, height } }` → `metadata` に変更（GROQ 非サポートの二重ネスト投影）
- `defined(category._ref) ? (...) : []` → `select(defined(category._ref) => (...), [])` に変更（GROQ は三項演算子非サポート）
- `slug.current != ^.slug` → `^.slug.current` に修正（自分自身が関連記事に混入するバグ）

### `+server.ts`
- 共有 `client` から専用クライアント（`useCdn: false`）に切り替え（TRILL フィードと同様、`apicdn.sanity.io` 403 回避）
- 503 エラー時の `Cache-Control` を `no-store` に修正

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_