### PR TITLE
SmartNewsフィードにUser-Agentログを追加

### DIFF
--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -72,7 +72,8 @@ const safePortableTextToHtml = (blocks) => {
 	}
 };
 
-export async function GET() {
+export async function GET({ request }) {
+	console.log(`[SmartNews Feed] User-Agent: ${request.headers.get('user-agent') ?? 'unknown'}`);
 	try {
 		// 並列でデータを取得
 		const [articles, globalLatestQuizzes] = await Promise.all([


### PR DESCRIPTION
## 概要

SmartNewsのクロール開始を確認するため、`/feed/smartnews` エンドポイントにUser-Agentのログ出力を追加しました。

## 変更内容

- `GET` 関数の引数に `{ request }` を追加
- アクセス時のUser-Agentを `console.log` で出力

## 確認方法

デプロイ後、Vercel ダッシュボード → Logs → `[SmartNews Feed]` で検索すると、アクセスしてきたクローラーのUser-Agentが確認できます。

SmartNewsのクローラーが来た場合:
```
[SmartNews Feed] User-Agent: Crawlerest/... SmartNews/...
```

## 注意

`console.log` はサーバー側のみで動作するため、レスポンスのXML（SmartFormat）には影響しません。

---
_Generated by [Claude Code](https://claude.ai/code/session_01XJHHi3j3ff3dVjun9zUjtJ)_