### PR TITLE
feat: TRILLフィードから「さらにもう一問！」削除・答えページに別解注釈追加

### DIFF
--- a/src/routes/feed/trill/+server.ts
+++ b/src/routes/feed/trill/+server.ts
@@ -268,22 +268,6 @@ const buildContentHtml = (doc: any): string => {
 		if (closingHtml) parts.push(closingHtml);
 	}
 
-	// 「さらにもう一問！」セクション
-	// TRILL仕様: 画像は <figure> で独立、リンクは <p><a>、画像を <a> で囲まない
-	const related: any[] = Array.isArray(doc?.related) ? doc.related : [];
-	if (related.length > 0) {
-		parts.push('<h3>さらにもう一問！</h3>');
-		for (const entry of related) {
-			const slug = typeof entry?.slug === 'string' ? entry.slug.trim() : '';
-			const entryTitle = typeof entry?.title === 'string' ? entry.title.trim() : '';
-			if (!slug || !entryTitle) continue;
-			const link = getAbsoluteUrl(`/quiz/${slug}`);
-			const figure = renderTrillFigure(entry?.image, entryTitle);
-			if (figure) parts.push(figure);
-			parts.push(`<p><a href="${escapeAttr(link)}">▶ ${escapeXml(entryTitle)}</a></p>`);
-		}
-	}
-
 	return parts.join('');
 };
 

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -105,6 +105,8 @@
     </section>
   {/if}
 
+  <p class="answer-note">※複数の正解を持つ場合もございます。あくまでも一例のご紹介に留まることを、ご了承ください。</p>
+
   <nav class="back-nav">
     <a class="action-button secondary" href={questionPath}>
       <span aria-hidden="true">←</span>
@@ -261,6 +263,14 @@
 
   .section-body :global(p:last-child) {
     margin-bottom: 0;
+  }
+
+  .answer-note {
+    font-size: 0.85rem;
+    color: #6b7280;
+    line-height: 1.7;
+    text-align: center;
+    margin: 0;
   }
 
   .action-button {

--- a/src/routes/quiz/matchstick/article/[id]/answer/+page.svelte
+++ b/src/routes/quiz/matchstick/article/[id]/answer/+page.svelte
@@ -66,6 +66,8 @@
         </section>
       {/if}
 
+      <p class="answer-note">※複数の正解を持つ場合もございます。あくまでも一例のご紹介に留まることを、ご了承ください。</p>
+
       <nav class="back-nav">
         <a href={`/quiz/matchstick/article/${quiz._id}`}>問題ページに戻る</a>
       </nav>
@@ -126,6 +128,15 @@
   .answer-explanation p {
     white-space: pre-line;
     line-height: 1.8;
+    margin: 0;
+  }
+
+  .answer-note {
+    font-size: 0.85rem;
+    color: #6b7280;
+    line-height: 1.7;
+    text-align: center;
+    padding: 0 16px;
     margin: 0;
   }
 

--- a/src/routes/quiz/spot-the-difference/article/[id]/answer/+page.svelte
+++ b/src/routes/quiz/spot-the-difference/article/[id]/answer/+page.svelte
@@ -66,6 +66,8 @@
         </section>
       {/if}
 
+      <p class="answer-note">※複数の正解を持つ場合もございます。あくまでも一例のご紹介に留まることを、ご了承ください。</p>
+
       <nav class="back-nav">
         <a href={`/quiz/spot-the-difference/article/${quiz._id}`}>問題ページに戻る</a>
       </nav>
@@ -125,6 +127,15 @@
   .answer-explanation p {
     white-space: pre-line;
     line-height: 1.8;
+    margin: 0;
+  }
+
+  .answer-note {
+    font-size: 0.85rem;
+    color: #6b7280;
+    line-height: 1.7;
+    text-align: center;
+    padding: 0 16px;
     margin: 0;
   }
 


### PR DESCRIPTION
## 対応内容

### ① TRILLフィード — 「さらにもう一問！」セクションを削除
- `content:encoded` 内の `<h3>さらにもう一問！</h3>` と関連記事HTMLを削除
- `trill:relatedItem` タグ（TRILL仕様の関連記事メタデータ）はそのまま出力継続

### ② 答えページ — 別解の注釈を全記事に追加
以下3ページすべての解説セクション下に固定テキストを追加：

> ※複数の正解を持つ場合もございます。あくまでも一例のご紹介に留まることを、ご了承ください。

対象ページ：
- `quiz/[...slug]/answer` — 通常クイズ答えページ
- `quiz/matchstick/article/[id]/answer` — マッチ棒クイズ答えページ
- `quiz/spot-the-difference/article/[id]/answer` — 間違い探し答えページ

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_