### PR TITLE
feat: TRILLフィードの記事に別解注釈を追加

### DIFF
--- a/src/routes/feed/trill/+server.ts
+++ b/src/routes/feed/trill/+server.ts
@@ -267,6 +267,7 @@ const buildContentHtml = (doc: any): string => {
 		if (answerHtml) parts.push(answerHtml);
 		if (closingHtml) parts.push(closingHtml);
 	}
+	parts.push('<p>※複数の正解を持つ場合もございます。あくまでも一例のご紹介に留まることを、ご了承ください。</p>');
 
 	return parts.join('');
 };


### PR DESCRIPTION
## Summary

- TRILLフィードの `content:encoded` 内、解答セクションの直後に別解注釈を追加
- 追加文言: `※複数の正解を持つ場合もございます。あくまでも一例のご紹介に留まることを、ご了承ください。`
- サイト本体の答えページへの注釈追加（PR #551）と同じ内容をTRILLフィードにも反映

## Test plan

- [ ] TRILLフィードの各記事の `content:encoded` に注釈段落が含まれることを確認
- [ ] 注釈は解答セクション（解答画像・解説・closing）の後に表示されることを確認

https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8

---
_Generated by [Claude Code](https://claude.ai/code/session_01RvgEcS9ibVetaL5P3cgoS8)_