### PR TITLE
記事構成の調整: タイトル下レクタングル広告・関連記事の多カテゴリ化・余白整理ほか

### DIFF
--- a/src/lib/components/QuizDetailPage.svelte
+++ b/src/lib/components/QuizDetailPage.svelte
@@ -198,9 +198,9 @@
     {/if}
   </header>
 
-  <!-- タイトル直下: レクタングルバナー広告（必須配信） -->
-  <!-- TODO: AdSense管理画面で新規発行したレクタングル広告ユニットのスロットIDに差し替え -->
-  <AdSense slot="0000000000" />
+  <!-- タイトル直下: 固定レクタングルバナー広告（必須配信） -->
+  <!-- noutorebiyori_記事内_タイトル下_固定レクタングル -->
+  <AdSense slot="4170928887" />
 
   {#if problemImageSet?.src}
     <div class="problem-image">

--- a/src/lib/components/QuizDetailPage.svelte
+++ b/src/lib/components/QuizDetailPage.svelte
@@ -198,6 +198,10 @@
     {/if}
   </header>
 
+  <!-- タイトル直下: レクタングルバナー広告（必須配信） -->
+  <!-- TODO: AdSense管理画面で新規発行したレクタングル広告ユニットのスロットIDに差し替え -->
+  <AdSense slot="0000000000" />
+
   {#if problemImageSet?.src}
     <div class="problem-image">
       <picture>
@@ -434,6 +438,12 @@
     margin-bottom: 0;
   }
 
+  /* 広告がまだ表示されていない（読み込み中／未配信）枠が
+     上下それぞれの flex gap を確保して二重の余白になるのを防ぐ（トルツメ） */
+  .quiz-detail :global(.adsense-container:not(.revealed)) {
+    margin-top: -24px;
+  }
+
   .hints-toggle,
   .to-answer,
   .category-nav {
@@ -545,6 +555,10 @@
     .quiz-detail {
       margin-top: 16px;
       gap: 20px;
+    }
+
+    .quiz-detail :global(.adsense-container:not(.revealed)) {
+      margin-top: -20px;
     }
 
     .quiz-header {

--- a/src/lib/server/related-quizzes.js
+++ b/src/lib/server/related-quizzes.js
@@ -4,44 +4,32 @@ import { resolvePublishedDate } from '$lib/utils/publishedDate.js';
 import {
   QUIZ_ORDER_BY_PUBLISHED,
   QUIZ_PUBLISHED_FILTER,
-  filterVisibleQuizzes
+  filterVisibleQuizzes,
 } from '$lib/queries/quizVisibility.js';
 
-const RELATED_QUERY = /* groq */ `{
-  "matchstick": *[
-    _type == "quiz"
-    && defined(slug.current)
-    && slug.current != $slug
-    ${QUIZ_PUBLISHED_FILTER}
-    && isRepublished != true
-    && defined(category._ref)
-    && category->slug.current == "matchstick-quiz"
-  ] | order(${QUIZ_ORDER_BY_PUBLISHED})[0...6]{
-    ${QUIZ_PREVIEW_PROJECTION}
-  },
-  "kanji": *[
-    _type == "quiz"
-    && defined(slug.current)
-    && slug.current != $slug
-    ${QUIZ_PUBLISHED_FILTER}
-    && isRepublished != true
-    && defined(category._ref)
-    && category->slug.current in ["kanji-quiz", "nandoku-kanji"]
-  ] | order(${QUIZ_ORDER_BY_PUBLISHED})[0...6]{
-    ${QUIZ_PREVIEW_PROJECTION}
-  },
-  "number": *[
-    _type == "quiz"
-    && defined(slug.current)
-    && slug.current != $slug
-    ${QUIZ_PUBLISHED_FILTER}
-    && isRepublished != true
-    && defined(category._ref)
-    && category->slug.current == "number-quiz"
-  ] | order(${QUIZ_ORDER_BY_PUBLISHED})[0...6]{
-    ${QUIZ_PREVIEW_PROJECTION}
-  }
+// 関連記事は特定カテゴリに限定せず、全カテゴリの公開済み記事を新着順に取得する。
+// 取得後、JS側でカテゴリごとにグルーピングし「直近更新があるカテゴリ」のみを対象に
+// ラウンドロビンで詰めることで、いろいろなカテゴリをバランス良く掲載する。
+const RELATED_QUERY = /* groq */ `*[
+  _type == "quiz"
+  && defined(slug.current)
+  && slug.current != $slug
+  ${QUIZ_PUBLISHED_FILTER}
+  && isRepublished != true
+  && defined(category._ref)
+  && defined(category->slug.current)
+] | order(${QUIZ_ORDER_BY_PUBLISHED})[0...150]{
+  ${QUIZ_PREVIEW_PROJECTION}
 }`;
+
+// このカテゴリの最新記事がこの日数より古い場合は「直近更新なし」とみなし掲載しない。
+const RECENT_CATEGORY_WINDOW_DAYS = 90;
+
+// 1カテゴリあたり最終的に掲載する最大件数（特定カテゴリ偏重を防ぐ）。
+const MAX_PER_CATEGORY = 4;
+
+// 関連記事として返す総件数。
+const TOTAL_RELATED = 12;
 
 const pickImage = (quiz) =>
   quiz?.problemImage?.asset?.url
@@ -85,8 +73,14 @@ const toPreview = (quiz) => {
     popularityScore: toMetric(quiz?.popularityScore),
     difficulty: quiz?.difficulty ?? null,
     readingTime: quiz?.readingTime ?? null,
-    textLength: toMetric(quiz?.textLength)
+    textLength: toMetric(quiz?.textLength),
   };
+};
+
+const toTimestamp = (value) => {
+  if (!value) return 0;
+  const ts = Date.parse(value);
+  return Number.isNaN(ts) ? 0 : ts;
 };
 
 export async function fetchRelatedQuizzes({ slug, categorySlug }) {
@@ -95,34 +89,52 @@ export async function fetchRelatedQuizzes({ slug, categorySlug }) {
   try {
     const payload = await client.fetch(RELATED_QUERY, { slug });
 
-    const matchstick = filterVisibleQuizzes(payload?.matchstick).map(toPreview).filter(Boolean);
-    const kanji = filterVisibleQuizzes(payload?.kanji).map(toPreview).filter(Boolean);
-    const number = filterVisibleQuizzes(payload?.number).map(toPreview).filter(Boolean);
+    // 公開済みのみ＆新着順（クエリで order 済み）の記事一覧
+    const quizzes = filterVisibleQuizzes(payload).map(toPreview).filter(Boolean);
 
+    // カテゴリごとにグルーピング（各グループ内は新着順を維持）
+    const groups = new Map();
+    for (const quiz of quizzes) {
+      const cslug = quiz.category?.slug;
+      if (!cslug) continue;
+      let group = groups.get(cslug);
+      if (!group) {
+        group = { slug: cslug, latest: 0, items: [] };
+        groups.set(cslug, group);
+      }
+      group.items.push(quiz);
+      const ts = toTimestamp(quiz.publishedAt);
+      if (ts > group.latest) group.latest = ts;
+    }
+
+    // 「直近更新があるカテゴリ」だけに絞り込む（更新が止まったカテゴリは掲載しない）
+    const now = Date.now();
+    const recentThreshold = now - RECENT_CATEGORY_WINDOW_DAYS * 24 * 60 * 60 * 1000;
+    let activeGroups = [...groups.values()].filter((group) => group.latest >= recentThreshold);
+
+    // 全カテゴリが閾値外の場合でも関連記事が空にならないようフォールバック
+    if (activeGroups.length === 0) {
+      activeGroups = [...groups.values()];
+    }
+
+    // 更新が新しいカテゴリ順に並べ、現在の記事と同じカテゴリは先頭に寄せる
+    activeGroups.sort((a, b) => b.latest - a.latest);
+    if (categorySlug) {
+      const idx = activeGroups.findIndex((group) => group.slug === categorySlug);
+      if (idx > 0) {
+        const [current] = activeGroups.splice(idx, 1);
+        activeGroups.unshift(current);
+      }
+    }
+
+    // 各カテゴリから1件ずつ順番に取り出すラウンドロビンで、
+    // 多様なカテゴリをバランス良く TOTAL_RELATED 件まで詰める
     const seen = new Set();
     const result = [];
-
-    // 各カテゴリから最大4件ずつ取得
-    const appendItems = (source, perCategory) => {
-      let added = 0;
-      for (const item of source) {
-        if (!item?.slug || seen.has(item.slug) || added >= perCategory) continue;
-        seen.add(item.slug);
-        result.push(item);
-        added++;
-      }
-    };
-
-    appendItems(matchstick, 4);
-    appendItems(kanji, 4);
-    appendItems(number, 4);
-
-    // 12件に満たない場合は各カテゴリから追加補充
-    const TOTAL = 12;
-    if (result.length < TOTAL) {
-      const all = [...matchstick, ...kanji, ...number];
-      for (const item of all) {
-        if (result.length >= TOTAL) break;
+    for (let round = 0; round < MAX_PER_CATEGORY && result.length < TOTAL_RELATED; round++) {
+      for (const group of activeGroups) {
+        if (result.length >= TOTAL_RELATED) break;
+        const item = group.items[round];
         if (!item?.slug || seen.has(item.slug)) continue;
         seen.add(item.slug);
         result.push(item);

--- a/src/lib/server/related-quizzes.js
+++ b/src/lib/server/related-quizzes.js
@@ -23,7 +23,7 @@ const RELATED_QUERY = /* groq */ `*[
 }`;
 
 // このカテゴリの最新記事がこの日数より古い場合は「直近更新なし」とみなし掲載しない。
-const RECENT_CATEGORY_WINDOW_DAYS = 90;
+const RECENT_CATEGORY_WINDOW_DAYS = 30;
 
 // 1カテゴリあたり最終的に掲載する最大件数（特定カテゴリ偏重を防ぐ）。
 const MAX_PER_CATEGORY = 4;

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -57,10 +57,11 @@
     navigatingPending = true;
   });
 
-  afterNavigate(({ type, to }) => {
+  afterNavigate(({ to }) => {
     navigatingPending = false;
     menuOpen = false;
-    if (type !== 'popstate' && !to?.url?.hash) {
+    // ページ読み込み・遷移後は必ずTOPを表示する（ページ内アンカー遷移は除く）
+    if (!to?.url?.hash) {
       requestAnimationFrame(() => {
         window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
       });
@@ -113,6 +114,13 @@
   });
 
   onMount(() => {
+    // リロードや直リンクでの読み込み時にブラウザが前回のスクロール位置を
+    // 復元しないようにし、必ずページのTOPから表示されるようにする
+    if ('scrollRestoration' in history) {
+      history.scrollRestoration = 'manual';
+    }
+    window.scrollTo({ top: 0, left: 0, behavior: 'instant' });
+
     // サイドレール広告を初期化（十分な画面幅がある場合のみ）
     if (window.innerWidth >= 1540) {
       mountSideRailAd(leftRailRef);

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -10,11 +10,6 @@
   const closingDefault =
     'このシリーズは毎日更新。明日も新作を公開します。ブックマークしてまた挑戦してください！';
 
-  // カテゴリリンク
-  const categorySlug = quiz?.category?.slug ?? null;
-  const categoryTitle = quiz?.category?.title ?? null;
-  const categoryHref = categorySlug ? `/category/${categorySlug}` : null;
-
   const escapeHtml = (value) =>
     value
       .replace(/&/g, '&amp;')
@@ -78,8 +73,11 @@
   <header class="quiz-header">
     <p class="quiz-meta" aria-hidden="true">答え合わせ</p>
     <h1 class="quiz-title">{quiz.title}｜正解</h1>
-    <p class="quiz-subtitle">なぜそうなるかを知ると、次の挑戦がもっと楽しくなります。</p>
   </header>
+
+  <!-- タイトル直下: レクタングルバナー広告（必須配信） -->
+  <!-- TODO: AdSense管理画面で新規発行したレクタングル広告ユニットのスロットIDに差し替え -->
+  <AdSense slot="0000000000" />
 
   {#if quiz.answerImage?.asset?.url}
     <div class="answer-image">
@@ -144,13 +142,6 @@
     </section>
   {/if}
 
-  {#if categoryHref && categoryTitle}
-    <a class="category-cta" href={categoryHref}>
-      <span class="category-cta__label">📂 {categoryTitle}の問題をもっと見る</span>
-      <span class="category-cta__arrow" aria-hidden="true">→</span>
-    </a>
-  {/if}
-
   <!-- 正解ページ: 関連記事上の広告 -->
   <AdSense slot="1724332823" />
 
@@ -196,12 +187,6 @@
     margin-bottom: 12px;
     color: #7c2d12;
     font-weight: 800;
-  }
-
-  .quiz-subtitle {
-    font-size: 1rem;
-    color: #9a3412;
-    opacity: 0.9;
   }
 
   .answer-image {
@@ -395,43 +380,20 @@
     overflow: hidden;
   }
 
-  /* ── カテゴリCTA ─────────────────────── */
-  .category-cta {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 1rem;
-    padding: 18px 24px;
-    background: linear-gradient(135deg, rgba(253, 224, 71, 0.4), rgba(251, 191, 36, 0.3));
-    border: 1.5px solid rgba(245, 158, 11, 0.45);
-    border-radius: 16px;
-    text-decoration: none;
-    color: #78350f;
-    font-weight: 700;
-    font-size: 1rem;
-    transition: background 0.2s ease, box-shadow 0.2s ease;
-    box-shadow: 0 4px 14px rgba(245, 158, 11, 0.12);
+  /* 広告がまだ表示されていない（読み込み中／未配信）枠が
+     上下それぞれの flex gap を確保して二重の余白になるのを防ぐ（トルツメ） */
+  .answer-page :global(.adsense-container:not(.revealed)) {
+    margin-top: -24px;
   }
-
-  .category-cta:hover {
-    background: linear-gradient(135deg, rgba(251, 191, 36, 0.55), rgba(245, 158, 11, 0.45));
-    box-shadow: 0 8px 24px rgba(245, 158, 11, 0.22);
-  }
-
-  .category-cta__label {
-    flex: 1;
-  }
-
-  .category-cta__arrow {
-    font-size: 1.1rem;
-    flex-shrink: 0;
-  }
-
 
   @media (max-width: 640px) {
     .answer-page {
       margin-top: 16px;
       gap: 20px;
+    }
+
+    .answer-page :global(.adsense-container:not(.revealed)) {
+      margin-top: -20px;
     }
 
     .quiz-header {

--- a/src/routes/quiz/[...slug]/answer/+page.svelte
+++ b/src/routes/quiz/[...slug]/answer/+page.svelte
@@ -75,9 +75,9 @@
     <h1 class="quiz-title">{quiz.title}｜正解</h1>
   </header>
 
-  <!-- タイトル直下: レクタングルバナー広告（必須配信） -->
-  <!-- TODO: AdSense管理画面で新規発行したレクタングル広告ユニットのスロットIDに差し替え -->
-  <AdSense slot="0000000000" />
+  <!-- タイトル直下: 固定レクタングルバナー広告（必須配信） -->
+  <!-- noutorebiyori_記事内_タイトル下_固定レクタングル -->
+  <AdSense slot="4170928887" />
 
   {#if quiz.answerImage?.asset?.url}
     <div class="answer-image">


### PR DESCRIPTION
## 概要
問題ページ・正解ページの記事構成を調整しました。

## 変更内容

### 1. タイトル直下にレクタングルバナー広告を追加（必須配信）
- 問題ページ（`QuizDetailPage.svelte`）・正解ページ（`answer/+page.svelte`）のタイトル直下に広告枠を追加
- スロットID: `4170928887`（`noutorebiyori_記事内_タイトル下_固定レクタングル`）
- 既存 `AdSense` コンポーネントを使用（client `ca-pub-2298313897414846` / `data-ad-format="auto"` / `data-full-width-responsive="true"`）

### 2. 正解ページのサブタイトル削除
- 「なぜそうなるかを知ると、次の挑戦がもっと楽しくなります。」を削除（関連CSSも削除）

### 3. 「さらにもう一問！」下部のカテゴリ導線を削除
- `category-cta`（📂◯◯の問題をもっと見る）ブロックと未使用変数・CSSを削除

### 4. 関連記事を多カテゴリ化（直近更新なしカテゴリは除外）
- 全カテゴリの公開済み記事を取得 → カテゴリごとにグルーピング
- **最新記事が30日以内のカテゴリのみ**を対象に、ラウンドロビンで多様に最大12件抽出（`related-quizzes.js`）
- 閾値は `RECENT_CATEGORY_WINDOW_DAYS`、1カテゴリ上限は `MAX_PER_CATEGORY` で調整可能
- 全カテゴリが閾値外でも空にならないようフォールバックあり

### 5. 不自然な余白のトルツメ
- 空（読み込み中／未配信）の広告枠が上下それぞれの flex gap を確保して二重余白になる問題を、未表示時にマージンを相殺して解消

### 6. ページ読み込み後は必ずTOPを表示
- `history.scrollRestoration = 'manual'` を設定し、マウント時・遷移後に先頭へスクロール（ページ内アンカー遷移は除外）

## 確認
- `pnpm build` 成功
- 既存のstub環境テスト（`pnpm test`）の503は本変更前から同様に発生する既知の環境要因で、本変更とは無関係

https://claude.ai/code/session_014vXSxtR4gcedcSJqeCgdga

---
_Generated by [Claude Code](https://claude.ai/code/session_014vXSxtR4gcedcSJqeCgdga)_