### PR TITLE
ThreadsボタンをInstaグラデから黒背景に変更

### DIFF
--- a/src/lib/components/SnsFollowCard.svelte
+++ b/src/lib/components/SnsFollowCard.svelte
@@ -92,7 +92,7 @@
   }
 
   .sns-btn.threads {
-    background: linear-gradient(135deg, #833ab4 0%, #e1306c 50%, #f77737 100%);
+    background: #000;
   }
 
   @media (max-width: 400px) {


### PR DESCRIPTION
Threads公式ブランドの黒背景・白ロゴに変更。将来のInstagram追加時にグラデーションが被らないよう対応。

---
_Generated by [Claude Code](https://claude.ai/code/session_01DT2LAAMuFSxbt42stHAHmz)_