### PR TITLE
fix: SmartNews向けRSSの外部リンクガイドライン違反とitem.link不一致を修正

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -16,3 +16,11 @@ VITE_SANITY_DATASET=production
 VITE_SANITY_API_VERSION=2024-01-01
 VITE_GA_ID=G-XXXXXXXXXX
 
+# SmartNewsフィード(/feed/smartnews)の「さらにもう一問！」出し分け用。
+# ここに指定したUser-Agent(部分一致・カンマ区切り)からのアクセスにのみ
+# 「さらにもう一問！」(画像付き)を出力する。SmartNewsには出さない(NG事例4対応)。
+# ママテナ／イチオシのクローラーUAを本番ログで確認して設定する。
+# 例: RSS_PARTNER_USER_AGENTS=mamatena,ichioshi,SomeFeedFetcher/1.0
+# 未設定時の既定値: mamatena,ichioshi
+RSS_PARTNER_USER_AGENTS=
+

--- a/.env.local.example
+++ b/.env.local.example
@@ -16,11 +16,3 @@ VITE_SANITY_DATASET=production
 VITE_SANITY_API_VERSION=2024-01-01
 VITE_GA_ID=G-XXXXXXXXXX
 
-# SmartNewsフィード(/feed/smartnews)の「さらにもう一問！」出し分け用。
-# ここに指定したUser-Agent(部分一致・カンマ区切り)からのアクセスにのみ
-# 「さらにもう一問！」(画像付き)を出力する。SmartNewsには出さない(NG事例4対応)。
-# ママテナ／イチオシのクローラーUAを本番ログで確認して設定する。
-# 例: RSS_PARTNER_USER_AGENTS=mamatena,ichioshi,SomeFeedFetcher/1.0
-# 未設定時の既定値: mamatena,ichioshi
-RSS_PARTNER_USER_AGENTS=
-

--- a/docs/smartnews-duplicate-slug-fix.md
+++ b/docs/smartnews-duplicate-slug-fix.md
@@ -1,0 +1,96 @@
+# SmartNews向けRSS：重複スラッグの調査・修正手順（タスクB）
+
+SmartNews からの指摘②「item.link の URL と記事内容が異なる／遷移先がエラー」の
+**根本原因＝重複スラッグ** を、Sanity 上で調査・修正するための手順書です。
+
+> コード側の対策（canonical URL 化・重複除外・slug の isUnique 検証）は実装済みですが、
+> **すでに Sanity に存在している重複スラッグのデータ自体** はコードでは直せないため、
+> 本手順で手動修正が必要です。
+
+---
+
+## 背景（なぜ起きるか）
+
+- クイズ記事ページは `slug.current == $slug` の先頭1件（`[0]`）で解決される。
+- そのため **複数のクイズが同じ `slug.current` を持つ**と、リンク先が「別の記事」に解決され、
+  フィードのタイトルと中身が食い違う（最悪、遷移先がエラー＝404）。
+- 特に **再公開記事（`isRepublished == true`）が元記事と同じスラッグを再利用している**ケースが疑わしい。
+
+---
+
+## 手順1：重複スラッグを洗い出す
+
+Sanity Studio の **Vision（GROQ プレイグラウンド）** で以下を実行します。
+
+```groq
+*[
+  _type == "quiz" &&
+  !(_id in path("drafts.**")) &&
+  defined(slug.current)
+]{
+  _id,
+  title,
+  "slug": slug.current,
+  publishedAt,
+  isRepublished,
+  "duplicateCount": count(*[
+    _type == "quiz" &&
+    !(_id in path("drafts.**")) &&
+    slug.current == ^.slug.current
+  ])
+}[duplicateCount > 1] | order(slug asc, publishedAt desc)
+```
+
+- 同じ `slug` を持つ記事が **slug 順に並んで** 表示されます（**0件なら重複なし**）。
+- `isRepublished` 列を見て、再公開記事が重複元になっていないか確認します。
+
+---
+
+## 手順2：指摘された記事を直接確認（任意）
+
+SmartNews が具体例として挙げた記事を確認する場合：
+
+```groq
+*[_type == "quiz" && (
+  title match "*答えは*" ||
+  title match "*30を作ろう*" ||
+  title match "*博識*" ||
+  title match "*アナグラム*"
+)]{ _id, title, "slug": slug.current, isRepublished, publishedAt } | order(slug asc)
+```
+
+> スラッグの形式が分かっている場合は、`slug.current in ["...", "..."]` で直接引くのが確実です。
+> 例：`*[_type == "quiz" && slug.current in ["arithmetic-quiz/182","formula-puzzle/27","kanji-quiz/246"]]{ _id, title, "slug": slug.current }`
+
+---
+
+## 手順3：修正する
+
+手順1で見つかった **各重複グループ（同じ slug・複数記事）** について、次を行います。
+
+1. **「正」とする記事を1つ決める**（通常はスラッグの内容と一致する元記事）。
+2. もう一方（多くは `isRepublished == true` の再公開記事）の **slug を一意な値に変更して再公開**する。
+   - 例：内容に合った新しいスラッグにする／末尾に識別子・連番を付ける。
+3. その重複記事が不要なら、**非公開化または削除**も検討する。
+
+> 本コードをデプロイ後は Studio 側に slug の重複チェック（`isUnique`）が効くため、
+> スラッグ変更時に重複があれば警告が出ます。
+
+---
+
+## 手順4：確認する
+
+1. **手順1のクエリを再実行** → 結果が **0件** になれば重複は解消。
+2. 本番反映後、**SmartFormat チェックツール**で再検証：
+   https://sf-validator.smartnews.com/
+
+---
+
+## 補足：再発防止
+
+- quiz スキーマの `slug` に **`isUnique` 検証を追加済み**のため、今後 Studio 上での重複公開はブロックされます。
+- ただし **API 経由のアップロード（`sanity_upload.mjs` 等）は Studio の検証を通りません**。
+  スクリプトで記事を作成する場合は、スラッグの一意性に注意してください。
+- フィードはコード側でも「同一スラッグは最新1件のみ」に絞るため、重複が残っていても
+  フィード内に同じ item.link が二重に出ることはありません（ただし“どの記事に解決されるか”は
+  データを直さない限り保証されないため、本手順での修正が必要です）。

--- a/src/lib/queries/rssSmartnews.groq.js
+++ b/src/lib/queries/rssSmartnews.groq.js
@@ -35,7 +35,8 @@ export const RSS_SMARTNEWS_QUERY = /* groq */ `
   "category": category->{
     _id,
     name,
-    title
+    title,
+    "slug": slug.current
   },
 
   // 関連記事
@@ -50,6 +51,8 @@ export const RSS_SMARTNEWS_QUERY = /* groq */ `
     title,
     "slug": slug.current,
     _type,
+    // カテゴリ別 canonical URL を組み立てるためのカテゴリスラッグ
+    "categorySlug": category->slug.current,
     // 【修正】関連記事の画像アセット情報を追加
     mainImage{asset->},
     problemImage{asset->}

--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -3,7 +3,6 @@ import { urlFor } from '$lib/sanity/client';
 import { RSS_SMARTNEWS_QUERY } from '$lib/queries/rssSmartnews.groq';
 import { portableTextToHtml } from '$lib/utils/portableText';
 import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
-import { env } from '$env/dynamic/private';
 
 const siteTitle = '脳トレ日和';
 const siteLink = 'https://noutorebiyori.com/';
@@ -20,35 +19,21 @@ const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_PUBLISHED_
   mainImage
 }`;
 
-// 「さらにもう一問！」(本文内の画像付き外部リンク) を出力する配信先かを判定する。
+// 「さらにもう一問！」(本文内の画像付き外部リンク) を出力するかどうかを判定する。
 //
 // この本文内画像リンクは SmartFormat 外部リンクガイドライン NG事例4
 //（最終パラグラフ以降に画像でクイズを出題し遷移させる）に該当するため、
-// SmartNews には出してはいけない。一方でママテナ／イチオシ等のパートナー配信では
-// 継続して表示したい。そこで「既定では出さない（= SmartNews 準拠）」とし、
-// 明示的にパートナー判定できた場合のみ出力する。こうしておけば、
-// User-Agent が未知の場合でも SmartNews 側は常に準拠版となり違反が再発しない。
+// SmartNews には絶対に出してはいけない。
 //
-// 判定条件（いずれか）:
-//  1. クエリ ?variant=full が付いている（パートナー側で確実に切り替えたい場合の明示指定）
-//  2. User-Agent が RSS_PARTNER_USER_AGENTS（環境変数・カンマ区切り）のいずれかを含む
-const DEFAULT_PARTNER_UA_PATTERNS = ['mamatena', 'ichioshi'];
-
-const resolveIncludeNextChallenge = ({ userAgent = '', variant = '' }) => {
-	if (typeof variant === 'string' && variant.toLowerCase() === 'full') return true;
-
-	const raw = env.RSS_PARTNER_USER_AGENTS;
-	const patterns =
-		typeof raw === 'string' && raw.trim()
-			? raw
-					.split(',')
-					.map((s) => s.trim().toLowerCase())
-					.filter(Boolean)
-			: DEFAULT_PARTNER_UA_PATTERNS;
-
-	const ua = String(userAgent).toLowerCase();
-	return patterns.some((pattern) => ua.includes(pattern));
-};
+// 【最重要】SmartNews が登録している素の URL (/feed/smartnews) では、
+// この関数は必ず false を返す（= 常に準拠版）。出力可否を URL のクエリだけで決め、
+// User-Agent 等の推測判定は一切行わない。これにより、CDN キャッシュの取り違えや
+// UA の偽装・変更があっても、SmartNews 側に違反版が出る経路が構造的に存在しない。
+//
+// ママテナ／イチオシ等のパートナーには、明示的に ?variant=full を付けた
+// 別 URL（キャッシュキーも別）を渡してもらうことで「さらにもう一問！」を表示する。
+const resolveIncludeNextChallenge = ({ variant = '' }) =>
+	typeof variant === 'string' && variant.toLowerCase() === 'full';
 
 // クイズの canonical URL（カテゴリ別 URL）を生成するヘルパー。
 // サイト側 (/quiz/[...slug]) は単一セグメントのスラッグを
@@ -122,8 +107,8 @@ export async function GET({ request, url }) {
 	const userAgent = request.headers.get('user-agent') ?? 'unknown';
 	const variant = url.searchParams.get('variant') ?? '';
 	// 「さらにもう一問！」(NG事例4 に該当する本文内画像リンク) を出すかどうか。
-	// 既定は false（SmartNews 準拠）。パートナー配信時のみ true。
-	const includeNextChallenge = resolveIncludeNextChallenge({ userAgent, variant });
+	// 判定は URL のクエリ(?variant=full)のみ。素の URL は常に false（= SmartNews 準拠）。
+	const includeNextChallenge = resolveIncludeNextChallenge({ variant });
 	console.log(
 		`[SmartNews Feed] User-Agent: ${userAgent} / variant: ${variant || 'none'} / includeNextChallenge: ${includeNextChallenge}`
 	);
@@ -329,12 +314,10 @@ export async function GET({ request, url }) {
 		return new Response(xml, {
 			headers: {
 				'Content-Type': 'application/xml',
-				// 出力は User-Agent（パートナー判定）で変わるため、共有キャッシュが
-				// パートナー版を SmartNews へ配信しないよう Vary: User-Agent を付与し、
-				// 取り違えの窓を小さくするため s-maxage も短めにする。
-				// ?variant=full の場合は URL 自体が異なるためキャッシュキーも分かれる。
-				'Cache-Control': 'max-age=0, s-maxage=600',
-				Vary: 'User-Agent'
+				// 出力は URL のクエリ(?variant=full の有無)だけで決まり、クエリ文字列は
+				// CDN のキャッシュキーに含まれるため、素の URL とパートナー URL の
+				// キャッシュは自然に分離される。User-Agent には依存しない。
+				'Cache-Control': 'max-age=0, s-maxage=3600'
 			}
 		});
 	} catch (err) {

--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -3,6 +3,7 @@ import { urlFor } from '$lib/sanity/client';
 import { RSS_SMARTNEWS_QUERY } from '$lib/queries/rssSmartnews.groq';
 import { portableTextToHtml } from '$lib/utils/portableText';
 import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
+import { env } from '$env/dynamic/private';
 
 const siteTitle = '脳トレ日和';
 const siteLink = 'https://noutorebiyori.com/';
@@ -18,6 +19,36 @@ const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_PUBLISHED_
   problemImage,
   mainImage
 }`;
+
+// 「さらにもう一問！」(本文内の画像付き外部リンク) を出力する配信先かを判定する。
+//
+// この本文内画像リンクは SmartFormat 外部リンクガイドライン NG事例4
+//（最終パラグラフ以降に画像でクイズを出題し遷移させる）に該当するため、
+// SmartNews には出してはいけない。一方でママテナ／イチオシ等のパートナー配信では
+// 継続して表示したい。そこで「既定では出さない（= SmartNews 準拠）」とし、
+// 明示的にパートナー判定できた場合のみ出力する。こうしておけば、
+// User-Agent が未知の場合でも SmartNews 側は常に準拠版となり違反が再発しない。
+//
+// 判定条件（いずれか）:
+//  1. クエリ ?variant=full が付いている（パートナー側で確実に切り替えたい場合の明示指定）
+//  2. User-Agent が RSS_PARTNER_USER_AGENTS（環境変数・カンマ区切り）のいずれかを含む
+const DEFAULT_PARTNER_UA_PATTERNS = ['mamatena', 'ichioshi'];
+
+const resolveIncludeNextChallenge = ({ userAgent = '', variant = '' }) => {
+	if (typeof variant === 'string' && variant.toLowerCase() === 'full') return true;
+
+	const raw = env.RSS_PARTNER_USER_AGENTS;
+	const patterns =
+		typeof raw === 'string' && raw.trim()
+			? raw
+					.split(',')
+					.map((s) => s.trim().toLowerCase())
+					.filter(Boolean)
+			: DEFAULT_PARTNER_UA_PATTERNS;
+
+	const ua = String(userAgent).toLowerCase();
+	return patterns.some((pattern) => ua.includes(pattern));
+};
 
 // クイズの canonical URL（カテゴリ別 URL）を生成するヘルパー。
 // サイト側 (/quiz/[...slug]) は単一セグメントのスラッグを
@@ -87,8 +118,15 @@ const safePortableTextToHtml = (blocks) => {
 	}
 };
 
-export async function GET({ request }) {
-	console.log(`[SmartNews Feed] User-Agent: ${request.headers.get('user-agent') ?? 'unknown'}`);
+export async function GET({ request, url }) {
+	const userAgent = request.headers.get('user-agent') ?? 'unknown';
+	const variant = url.searchParams.get('variant') ?? '';
+	// 「さらにもう一問！」(NG事例4 に該当する本文内画像リンク) を出すかどうか。
+	// 既定は false（SmartNews 準拠）。パートナー配信時のみ true。
+	const includeNextChallenge = resolveIncludeNextChallenge({ userAgent, variant });
+	console.log(
+		`[SmartNews Feed] User-Agent: ${userAgent} / variant: ${variant || 'none'} / includeNextChallenge: ${includeNextChallenge}`
+	);
 	try {
 		// 並列でデータを取得
 		const [articles, globalLatestQuizzes] = await Promise.all([
@@ -115,7 +153,7 @@ export async function GET({ request }) {
 			return true;
 		});
 
-		const buildItem = async (article, globalLatestQuizzes) => {
+		const buildItem = async (article, globalLatestQuizzes, includeNextChallenge) => {
 			// 記事URL（クイズはカテゴリ別 canonical URL を使用）
 			let articleLink;
 			if (article._type === 'quiz') {
@@ -166,10 +204,17 @@ export async function GET({ request }) {
 
 			// 「さらにもう一問」セクションの追加
 			// 【SmartFormat外部リンクガイドライン対応】
-			// 本文内に画像付きの外部リンクを置くと「リンク先へ遷移しなければ記事の閲覧体験が
-			// 完結しないコンテンツへの外部リンク」(ガイドライン1)3) と見なされ違反になるため、
-			// 画像は配置せず、最終パラグラフ以降の関連記事扱いとしてテキストリンクのみ（最大3本）を設置する。
-			if (article._type === 'quiz' && article.relatedLinks && article.relatedLinks.length > 0) {
+			// 本文内の画像付き外部リンクは NG事例4（最終パラグラフ以降に画像でクイズを出題し
+			// 遷移させる）に該当するため、SmartNews へは出力しない（includeNextChallenge=false）。
+			// ママテナ／イチオシ等のパートナー配信時（includeNextChallenge=true）のみ、
+			// 従来どおり画像付きで表示する。
+			// ※ SmartNews 向けの関連記事は、本文外の <snf:relatedLink> で別途提供している。
+			if (
+				includeNextChallenge &&
+				article._type === 'quiz' &&
+				article.relatedLinks &&
+				article.relatedLinks.length > 0
+			) {
 				let nextChallengeHtml = '<br /><br /><h3>さらにもう一問！</h3>';
 
 				for (const post of article.relatedLinks) {
@@ -177,9 +222,15 @@ export async function GET({ request }) {
 
 					const postUrl = buildQuizUrl(post.slug, post.categorySlug ?? article.category?.slug);
 					const title = escapeXml(post.title);
+					const imageUrl = getImageUrl(post.problemImage) || getImageUrl(post.mainImage);
 
-					// テキストリンクのみ（画像なし）
-					nextChallengeHtml += `<p>▶ <a href="${postUrl}">${title}</a></p>`;
+					if (imageUrl) {
+						nextChallengeHtml +=
+							`<p><a href="${postUrl}"><img src="${imageUrl}" alt="" /></a></p>` +
+							`<p>▶ <a href="${postUrl}">${title}</a></p>`;
+					} else {
+						nextChallengeHtml += `<p>▶ <a href="${postUrl}">${title}</a></p>`;
+					}
 				}
 				contentHtml += nextChallengeHtml;
 			}
@@ -248,7 +299,9 @@ export async function GET({ request }) {
 		`.trim();
 		};
 
-		const itemsArray = await Promise.all(dedupedArticles.map((article) => buildItem(article, globalLatestQuizzes)));
+		const itemsArray = await Promise.all(
+			dedupedArticles.map((article) => buildItem(article, globalLatestQuizzes, includeNextChallenge))
+		);
 		const items = itemsArray.join('\n');
 
 		// XML全体
@@ -276,7 +329,12 @@ export async function GET({ request }) {
 		return new Response(xml, {
 			headers: {
 				'Content-Type': 'application/xml',
-				'Cache-Control': 'max-age=0, s-maxage=3600'
+				// 出力は User-Agent（パートナー判定）で変わるため、共有キャッシュが
+				// パートナー版を SmartNews へ配信しないよう Vary: User-Agent を付与し、
+				// 取り違えの窓を小さくするため s-maxage も短めにする。
+				// ?variant=full の場合は URL 自体が異なるためキャッシュキーも分かれる。
+				'Cache-Control': 'max-age=0, s-maxage=600',
+				Vary: 'User-Agent'
 			}
 		});
 	} catch (err) {

--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -1,4 +1,5 @@
-import { client, urlFor } from '$lib/sanity/client';
+import { client } from '$lib/sanity.server.js';
+import { urlFor } from '$lib/sanity/client';
 import { RSS_SMARTNEWS_QUERY } from '$lib/queries/rssSmartnews.groq';
 import { portableTextToHtml } from '$lib/utils/portableText';
 import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
@@ -13,9 +14,23 @@ const siteLogo = 'https://noutorebiyori.com/logo.png';
 const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_PUBLISHED_FILTER}] | order(publishedAt desc)[0...8]{
   title,
   "slug": slug.current,
+  "categorySlug": category->slug.current,
   problemImage,
   mainImage
 }`;
+
+// クイズの canonical URL（カテゴリ別 URL）を生成するヘルパー。
+// サイト側 (/quiz/[...slug]) は単一セグメントのスラッグを
+// /category/{categorySlug}/{slug} へ 308 リダイレクトしているため、
+// フィードでは最初から canonical URL を出力し、リダイレクトを経ずに
+// 正しい記事へ到達できるようにする（item.link と記事内容の不一致・404 を防ぐ）。
+// 複数セグメントのスラッグ（matchstick 等の特殊記事）は従来どおり /quiz/{slug}。
+const buildQuizUrl = (slug, categorySlug) => {
+	if (categorySlug && !String(slug).includes('/')) {
+		return `${siteLink}category/${categorySlug}/${slug}`;
+	}
+	return `${siteLink}quiz/${slug}`;
+};
 
 // 画像オブジェクトからURLを生成するヘルパー関数（安全対策版）
 const getImageUrl = (imageObject) => {
@@ -85,11 +100,26 @@ export async function GET({ request }) {
 			console.warn('No articles fetched for SmartNews RSS');
 		}
 
+		// 同一スラッグの記事（再公開記事などスラッグが重複したドキュメント）が複数存在すると、
+		// item.link が同一 URL を指して重複したり、リンク先が別ドキュメントに解決されて
+		// 「item.link と記事内容が一致しない」事象につながる。スラッグ単位で最新の1件のみに絞り込む。
+		// （order(publishedAt desc) 済みのため先頭が最新）
+		const seenSlugs = new Set();
+		const dedupedArticles = (articles || []).filter((article) => {
+			if (!article?.slug) return false;
+			if (seenSlugs.has(article.slug)) {
+				console.warn(`[SmartNews Feed] Duplicate slug skipped: ${article.slug} (_id: ${article._id})`);
+				return false;
+			}
+			seenSlugs.add(article.slug);
+			return true;
+		});
+
 		const buildItem = async (article, globalLatestQuizzes) => {
-			// 記事URL
+			// 記事URL（クイズはカテゴリ別 canonical URL を使用）
 			let articleLink;
 			if (article._type === 'quiz') {
-				articleLink = `${siteLink}quiz/${article.slug}`;
+				articleLink = buildQuizUrl(article.slug, article.category?.slug);
 			} else {
 				articleLink = `${siteLink}${article.slug}`;
 			}
@@ -135,29 +165,21 @@ export async function GET({ request }) {
 			}
 
 			// 「さらにもう一問」セクションの追加
-			// 【MSN対策】
-			// 1. 画像を<a>タグで直接ラップ → MSNが画像とリンクを正しく紐付けられるようにする
-			// 2. alt="" に設定 → MSNが画像下にaltテキストをキャプションとして表示するのを防ぐ
-			// 3. タイトルは別行の<a>リンクとして表示
+			// 【SmartFormat外部リンクガイドライン対応】
+			// 本文内に画像付きの外部リンクを置くと「リンク先へ遷移しなければ記事の閲覧体験が
+			// 完結しないコンテンツへの外部リンク」(ガイドライン1)3) と見なされ違反になるため、
+			// 画像は配置せず、最終パラグラフ以降の関連記事扱いとしてテキストリンクのみ（最大3本）を設置する。
 			if (article._type === 'quiz' && article.relatedLinks && article.relatedLinks.length > 0) {
 				let nextChallengeHtml = '<br /><br /><h3>さらにもう一問！</h3>';
 
 				for (const post of article.relatedLinks) {
 					if (!post || !post.slug || !post.title) continue;
 
-					const postUrl = `https://noutorebiyori.com/quiz/${post.slug}`;
+					const postUrl = buildQuizUrl(post.slug, post.categorySlug ?? article.category?.slug);
 					const title = escapeXml(post.title);
-					const imageUrl = getImageUrl(post.problemImage) || getImageUrl(post.mainImage);
 
-					if (imageUrl) {
-						// 画像を<a>で直接ラップ（MSNのリンク紐付けに必要）
-						// alt=""にしてMSNが画像下にキャプションを表示するのを防ぐ
-						nextChallengeHtml += `<p><a href="${postUrl}"><img src="${imageUrl}" alt="" /></a></p>` +
-							`<p>▶ <a href="${postUrl}">${title}</a></p>`;
-					} else {
-						// 画像がない場合：タイトルリンクのみ
-						nextChallengeHtml += `<p>▶ <a href="${postUrl}">${title}</a></p>`;
-					}
+					// テキストリンクのみ（画像なし）
+					nextChallengeHtml += `<p>▶ <a href="${postUrl}">${title}</a></p>`;
 				}
 				contentHtml += nextChallengeHtml;
 			}
@@ -172,7 +194,7 @@ export async function GET({ request }) {
 				.filter((quiz) => quiz.slug !== article.slug)
 				.slice(0, 2)
 				.map((quiz) => {
-					const link = `${siteLink}quiz/${quiz.slug}`;
+					const link = buildQuizUrl(quiz.slug, quiz.categorySlug);
 					const thumbnailUrl = getImageUrl(quiz.problemImage) || getImageUrl(quiz.mainImage) || siteLogo;
 					const title = escapeXml(quiz.title);
 					return `<snf:sponsoredLink link="${link}" thumbnail="${thumbnailUrl}" title="${title}" advertiser="${siteTitle}"/>`;
@@ -192,7 +214,9 @@ export async function GET({ request }) {
 				.map((related) => {
 					if (!related.slug || !related.title) return null;
 					const relatedUrl =
-						related._type === 'quiz' ? `${siteLink}quiz/${related.slug}` : `${siteLink}${related.slug}`;
+						related._type === 'quiz'
+							? buildQuizUrl(related.slug, related.categorySlug ?? article.category?.slug)
+							: `${siteLink}${related.slug}`;
 
 					// 関連リンクの画像URL
 					const relatedThumb = getImageUrl(related.problemImage) || getImageUrl(related.mainImage);
@@ -224,7 +248,7 @@ export async function GET({ request }) {
 		`.trim();
 		};
 
-		const itemsArray = await Promise.all((articles || []).map((article) => buildItem(article, globalLatestQuizzes)));
+		const itemsArray = await Promise.all(dedupedArticles.map((article) => buildItem(article, globalLatestQuizzes)));
 		const items = itemsArray.join('\n');
 
 		// XML全体

--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -19,22 +19,6 @@ const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_PUBLISHED_
   mainImage
 }`;
 
-// 「さらにもう一問！」(本文内の画像付き外部リンク) を出力するかどうかを判定する。
-//
-// この本文内画像リンクは SmartFormat 外部リンクガイドライン NG事例4
-//（最終パラグラフ以降に画像でクイズを出題し遷移させる）に該当するため、
-// SmartNews には絶対に出してはいけない。
-//
-// 【最重要】SmartNews が登録している素の URL (/feed/smartnews) では、
-// この関数は必ず false を返す（= 常に準拠版）。出力可否を URL のクエリだけで決め、
-// User-Agent 等の推測判定は一切行わない。これにより、CDN キャッシュの取り違えや
-// UA の偽装・変更があっても、SmartNews 側に違反版が出る経路が構造的に存在しない。
-//
-// ママテナ／イチオシ等のパートナーには、明示的に ?variant=full を付けた
-// 別 URL（キャッシュキーも別）を渡してもらうことで「さらにもう一問！」を表示する。
-const resolveIncludeNextChallenge = ({ variant = '' }) =>
-	typeof variant === 'string' && variant.toLowerCase() === 'full';
-
 // クイズの canonical URL（カテゴリ別 URL）を生成するヘルパー。
 // サイト側 (/quiz/[...slug]) は単一セグメントのスラッグを
 // /category/{categorySlug}/{slug} へ 308 リダイレクトしているため、
@@ -103,15 +87,8 @@ const safePortableTextToHtml = (blocks) => {
 	}
 };
 
-export async function GET({ request, url }) {
-	const userAgent = request.headers.get('user-agent') ?? 'unknown';
-	const variant = url.searchParams.get('variant') ?? '';
-	// 「さらにもう一問！」(NG事例4 に該当する本文内画像リンク) を出すかどうか。
-	// 判定は URL のクエリ(?variant=full)のみ。素の URL は常に false（= SmartNews 準拠）。
-	const includeNextChallenge = resolveIncludeNextChallenge({ variant });
-	console.log(
-		`[SmartNews Feed] User-Agent: ${userAgent} / variant: ${variant || 'none'} / includeNextChallenge: ${includeNextChallenge}`
-	);
+export async function GET({ request }) {
+	console.log(`[SmartNews Feed] User-Agent: ${request.headers.get('user-agent') ?? 'unknown'}`);
 	try {
 		// 並列でデータを取得
 		const [articles, globalLatestQuizzes] = await Promise.all([
@@ -138,7 +115,7 @@ export async function GET({ request, url }) {
 			return true;
 		});
 
-		const buildItem = async (article, globalLatestQuizzes, includeNextChallenge) => {
+		const buildItem = async (article, globalLatestQuizzes) => {
 			// 記事URL（クイズはカテゴリ別 canonical URL を使用）
 			let articleLink;
 			if (article._type === 'quiz') {
@@ -187,37 +164,26 @@ export async function GET({ request, url }) {
 				contentHtml += convertNewlinesToBr(safePortableTextToHtml(article.body));
 			}
 
-			// 「さらにもう一問」セクションの追加
+			// 「関連記事」セクションの追加
 			// 【SmartFormat外部リンクガイドライン対応】
-			// 本文内の画像付き外部リンクは NG事例4（最終パラグラフ以降に画像でクイズを出題し
-			// 遷移させる）に該当するため、SmartNews へは出力しない（includeNextChallenge=false）。
-			// ママテナ／イチオシ等のパートナー配信時（includeNextChallenge=true）のみ、
-			// 従来どおり画像付きで表示する。
-			// ※ SmartNews 向けの関連記事は、本文外の <snf:relatedLink> で別途提供している。
-			if (
-				includeNextChallenge &&
-				article._type === 'quiz' &&
-				article.relatedLinks &&
-				article.relatedLinks.length > 0
-			) {
-				let nextChallengeHtml = '<br /><br /><h3>さらにもう一問！</h3>';
+			// 本文内に画像付きの外部リンクを置くと NG事例4（最終パラグラフ以降に画像でクイズを
+			// 出題し遷移させる）に該当し違反となるため、画像は付けない。
+			// SmartNews が許可する「最終パラグラフ以降の関連記事扱い・最大3本・テキストリンク」
+			// の形で出力する（relatedLinks クエリ側で最大3件に制限済み）。
+			// ※ この RSS は SmartNews・ママテナ・イチオシ共通で、いずれもこの準拠版を配信する。
+			if (article._type === 'quiz' && article.relatedLinks && article.relatedLinks.length > 0) {
+				let relatedHtml = '<br /><br /><h3>関連記事</h3>';
 
 				for (const post of article.relatedLinks) {
 					if (!post || !post.slug || !post.title) continue;
 
 					const postUrl = buildQuizUrl(post.slug, post.categorySlug ?? article.category?.slug);
 					const title = escapeXml(post.title);
-					const imageUrl = getImageUrl(post.problemImage) || getImageUrl(post.mainImage);
 
-					if (imageUrl) {
-						nextChallengeHtml +=
-							`<p><a href="${postUrl}"><img src="${imageUrl}" alt="" /></a></p>` +
-							`<p>▶ <a href="${postUrl}">${title}</a></p>`;
-					} else {
-						nextChallengeHtml += `<p>▶ <a href="${postUrl}">${title}</a></p>`;
-					}
+					// テキストリンクのみ（画像なし）
+					relatedHtml += `<p>▶ <a href="${postUrl}">${title}</a></p>`;
 				}
-				contentHtml += nextChallengeHtml;
+				contentHtml += relatedHtml;
 			}
 
 			// サムネイル画像
@@ -285,7 +251,7 @@ export async function GET({ request, url }) {
 		};
 
 		const itemsArray = await Promise.all(
-			dedupedArticles.map((article) => buildItem(article, globalLatestQuizzes, includeNextChallenge))
+			dedupedArticles.map((article) => buildItem(article, globalLatestQuizzes))
 		);
 		const items = itemsArray.join('\n');
 
@@ -314,9 +280,6 @@ export async function GET({ request, url }) {
 		return new Response(xml, {
 			headers: {
 				'Content-Type': 'application/xml',
-				// 出力は URL のクエリ(?variant=full の有無)だけで決まり、クエリ文字列は
-				// CDN のキャッシュキーに含まれるため、素の URL とパートナー URL の
-				// キャッシュは自然に分離される。User-Agent には依存しない。
 				'Cache-Control': 'max-age=0, s-maxage=3600'
 			}
 		});

--- a/studio/schemas/quiz.js
+++ b/studio/schemas/quiz.js
@@ -79,7 +79,27 @@ export default defineType({
       name: 'slug',
       title: 'スラッグ',
       type: 'slug',
-      options: { source: 'title', maxLength: 96 },
+      options: {
+        source: 'title',
+        maxLength: 96,
+        // スラッグの重複を防止する。
+        // 重複すると /category/{categorySlug}/{slug} や RSS の item.link が
+        // 別ドキュメントに解決され、SmartNews 等で「リンク先と記事内容が一致しない」
+        // 事象や 404 が発生するため、公開・下書きを問わず一意であることを保証する。
+        isUnique: async (slug, context) => {
+          const { document, getClient } = context
+          const client = getClient({ apiVersion: '2024-01-01' })
+          const id = (document?._id || '').replace(/^drafts\./, '')
+          const params = {
+            draft: `drafts.${id}`,
+            published: id,
+            slug
+          }
+          const query =
+            '!defined(*[_type == "quiz" && !(_id in [$draft, $published]) && slug.current == $slug][0]._id)'
+          return client.fetch(query, params)
+        }
+      },
       group: 'content',
       validation: (Rule) => Rule.required()
     }),


### PR DESCRIPTION
## 概要

SmartNews社（SmartFormat）から受けた2点の指摘に対応します。本RSS（`/feed/smartnews`）は SmartNews・ママテナ・イチオシ共通で利用されており、全配信先でガイドライン準拠版を配信します。

## 指摘① 外部リンクガイドライン違反（本文内の画像付き外部リンク）

- 記事末尾の「さらにもう一問！」が、画像付きの外部リンクでクイズへ誘導しており、**SmartFormat外部リンクガイドライン NG事例4**（最終パラグラフ以降に画像でクイズを出題し遷移させる）に該当していた。

**対応**
- 見出しを「さらにもう一問！」→**「関連記事」**に変更。
- **画像を撤去し、テキストリンクのみ**（最終パラグラフ以降の関連記事扱い・**最大3本**）に変更。
- ※ 本体サイト（クイズ回答ページ）の「さらにもう一問！」は**対象外（変更なし）**。

## 指摘② item.link の URL と記事内容が異なる／遷移先がエラー

根本原因は複数要因の複合：
1. canonical URL が `/category/{categorySlug}/{slug}` へ移行済みなのに、フィードが旧 `/quiz/{slug}` を出力し、308リダイレクト＋スラッグ曖昧マッチに依存していた。
2. **重複スラッグ**（再公開記事などで `slug.current` が重複）により、`slug.current == $slug [0]` が別記事に解決される。
3. CDN（`useCdn:true`）＋エッジキャッシュによる古いスナップショット配信。

**対応（コード側）**
- フィードの `item.link`／関連リンク／広告リンクを、リダイレクトを経ない**カテゴリ別 canonical URL** で出力。
- 同一スラッグの記事は**スラッグ単位で最新1件に絞り込み**、item.link の重複・別記事解決を防止。
- フィードのデータ取得を CDN 経由から**公開 perspective のサーバークライアント**に変更し、古いスナップショットの配信を防止。
- quiz スキーマの `slug` に **`isUnique` 検証**を追加し、Studio での重複公開をブロック（再発防止）。

**対応（データ側・別途要対応）**
- すでに Sanity に存在している重複スラッグはコードでは直せないため、手動修正が必要。
- 調査クエリ・修正手順を `docs/smartnews-duplicate-slug-fix.md` に追加。

## 変更ファイル

- `src/routes/feed/smartnews/+server.js` — 「関連記事」化（画像なし・テキスト3本）、canonical URL、重複除外、非CDN取得
- `src/lib/queries/rssSmartnews.groq.js` — categorySlug 取得を追加
- `studio/schemas/quiz.js` — slug の一意制約（`isUnique`）
- `docs/smartnews-duplicate-slug-fix.md` — 重複スラッグの調査・修正手順書（新規）

## マージ後のTODO（運用）

- [ ] 本番デプロイ
- [ ] `docs/smartnews-duplicate-slug-fix.md` に従い、Sanity の重複スラッグを修正
- [ ] SmartFormat チェックツールで再検証（https://sf-validator.smartnews.com/）
- [ ] SmartNews へ修正完了を返信

## 補足

- 既存の `pnpm test`（quiz詳細ページ）は、本ブランチ以前から `SKIP_SANITY` スタブ環境で 503 となる既知の失敗で、本変更とは無関係であることを確認済み。

https://claude.ai/code/session_011zFzjaPJrmyHjZXFtz1McF

---
_Generated by [Claude Code](https://claude.ai/code/session_011zFzjaPJrmyHjZXFtz1McF)_