### PR TITLE
fix: 本文に「null」が表示される記事をSmartNews RSSから除外

### DIFF
--- a/src/lib/queries/rssSmartnews.groq.js
+++ b/src/lib/queries/rssSmartnews.groq.js
@@ -1,12 +1,24 @@
 // src/lib/queries/rssSmartnews.groq.js
 
+// 本文に「null」が表示される（生成バグ）記事をフィードから除外するフィルタ。
+// 例：「11からnullは差が5」「6+7+null=15」のように、数値が埋まらず "null" が残ったもの。
+// ※ Sanity 側の本文を修正すれば該当しなくなり、自動的にフィードへ復帰する（self-healing）。
+export const EXCLUDE_NULL_TEXT_FILTER = /* groq */ `!(
+  pt::text(problemDescription) match "*null*" ||
+  pt::text(hints) match "*null*" ||
+  pt::text(answerExplanation) match "*null*" ||
+  pt::text(closingMessage) match "*null*" ||
+  pt::text(body) match "*null*"
+)`;
+
 // 公開済みの記事のみを取得するクエリ
 export const RSS_SMARTNEWS_QUERY = /* groq */ `
 *[
   (_type == "quiz" || _type == "post") &&
   !(_id in path("drafts.**")) &&
   defined(slug.current) &&
-  publishedAt < now()
+  publishedAt < now() &&
+  ${EXCLUDE_NULL_TEXT_FILTER}
 ] | order(publishedAt desc)[0...20]{
   _id,
   _type,
@@ -46,7 +58,8 @@ export const RSS_SMARTNEWS_QUERY = /* groq */ `
     defined(slug.current) &&
     publishedAt < now() &&
     _id != ^._id && // 自分自身を除外
-    category._ref == ^.category._ref // 同じカテゴリ (展開前の参照IDと比較)
+    category._ref == ^.category._ref && // 同じカテゴリ (展開前の参照IDと比較)
+    ${EXCLUDE_NULL_TEXT_FILTER} // 本文に "null" が出る記事は関連記事からも除外
   ] | order(publishedAt desc)[0...3]{
     title,
     "slug": slug.current,

--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -1,6 +1,6 @@
 import { client } from '$lib/sanity.server.js';
 import { urlFor } from '$lib/sanity/client';
-import { RSS_SMARTNEWS_QUERY } from '$lib/queries/rssSmartnews.groq';
+import { RSS_SMARTNEWS_QUERY, EXCLUDE_NULL_TEXT_FILTER } from '$lib/queries/rssSmartnews.groq';
 import { portableTextToHtml } from '$lib/utils/portableText';
 import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
 
@@ -10,8 +10,8 @@ const siteDescription =
 	'脳トレ日和は、間違い探しや計算問題などの脳トレクイズを通じて、毎日の習慣づくりをサポートする無料のWebメディアです。高齢者の方でも安心して楽しめるシンプルな操作性と見やすいデザインが特徴です。';
 const siteLogo = 'https://noutorebiyori.com/logo.png';
 
-// 最新クイズリスト（広告枠用）
-const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_PUBLISHED_FILTER}] | order(publishedAt desc)[0...8]{
+// 最新クイズリスト（広告枠用）。本文に "null" が出る記事は広告リンクからも除外する。
+const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_PUBLISHED_FILTER} && ${EXCLUDE_NULL_TEXT_FILTER}] | order(publishedAt desc)[0...8]{
   title,
   "slug": slug.current,
   "categorySlug": category->slug.current,


### PR DESCRIPTION
## 概要

AI生成パイプラインのバグにより、`answerExplanation` などの本文に文字列 **`null`** が残った記事（例：「11から**null**は差が5となります」「6+7+**null**=15」）が**約53件**存在します。SmartNews は編集品質面のチェックもあるため、これらを**フィードから除外**します。

SmartFormat の構造チェックは VALID ですが、本件は表示品質の問題のため別途対応します。

## 変更内容

- `EXCLUDE_NULL_TEXT_FILTER` を追加し、本文系フィールド
  （`problemDescription` / `hints` / `answerExplanation` / `closingMessage` / `body`）に `null` を含む記事を除外。
- 適用箇所：**メイン記事**・**関連記事（関連記事リンク／snf:relatedLink）**・**広告枠（snf:sponsoredLink）**。

## 設計上のポイント（self-healing）

- これは**一時対策**です。**Sanity 側の本文を修正すれば該当しなくなり、自動的にフィードへ復帰**します（除外は永続的な削除ではない）。
- フィードは「`null` を含まない記事」から上位20件を選ぶため、**件数は20件のまま**（古い正常記事でバックフィルされる）。

## 注意点

- フィルタは本文に文字列 `null` を含む記事を一律除外します。万一 `null` を正当に含む記事（例：プログラミング関連）があれば併せて除外されますが、脳トレ系コンテンツでは稀と判断しています。該当があれば調整可能です。
- **根本対応は本文側の修正**です。下記クエリで対象を洗い出せます（恒久対応を推奨）：

```groq
*[_type == "quiz" && !(_id in path("drafts.**")) && (
  pt::text(answerExplanation) match "*null*" ||
  pt::text(problemDescription) match "*null*" ||
  pt::text(hints) match "*null*" ||
  pt::text(closingMessage) match "*null*"
)]{ _id, title, "slug": slug.current }
```

https://claude.ai/code/session_011zFzjaPJrmyHjZXFtz1McF

---
_Generated by [Claude Code](https://claude.ai/code/session_011zFzjaPJrmyHjZXFtz1McF)_