### PR TITLE
Sanity APIリクエスト数削減：レイアウトキャッシュ追加 & RSS CDN切替

### DIFF
--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,30 +1,33 @@
 // src/routes/+layout.server.js
 import { client } from '$lib/sanity/client';
 
-// グロナビに表示したい項目の定義
 const MENU_ITEMS = [
   { title: 'マッチ棒クイズ', slug: 'matchstick-quiz' },
   { title: '読解クイズ', slug: 'reading-quiz' }
 ];
 
+const CATEGORY_QUERY = `*[_type == "category"]{title, "slug": slug.current}`;
+const CACHE_TTL = 10 * 60 * 1000; // 10分
+
+// サーバーインスタンス内で Sanity へのリクエストを10分に1回に抑えるキャッシュ
+let _cache = null;
+
 export const load = async ({ url }) => {
-  // 1. 現在のURL情報を取得
   const pathname = url.pathname;
 
-  // 2. Sanityからカテゴリーデータを取得（存在確認用）
-  const query = `*[_type == "category"]{title, "slug": slug.current}`;
-  const sanityCategories = await client.fetch(query).catch(() => []);
+  const now = Date.now();
+  if (!_cache || now - _cache.ts > CACHE_TTL) {
+    const sanityCategories = await client.fetch(CATEGORY_QUERY).catch(() => []);
+    _cache = { data: sanityCategories, ts: now };
+  }
 
-  // 3. メニューを構築（Sanityにデータがなくても強制的に表示）
   const categories = MENU_ITEMS.map(item => {
-    // Sanityにデータがあればそれを使う、なければ固定定義を使う
-    const found = sanityCategories.find(c => c.slug === item.slug);
+    const found = _cache.data.find(c => c.slug === item.slug);
     return found || item;
   });
 
   return {
     url: pathname,
-    categories: categories, // これがグロナビに渡されます
-    // その他必要なデータがあればここに追加
+    categories,
   };
 };

--- a/src/routes/rss/merkystyle.xml/+server.ts
+++ b/src/routes/rss/merkystyle.xml/+server.ts
@@ -14,7 +14,7 @@ const sanityClient = createClient({
   projectId: import.meta.env?.VITE_SANITY_PROJECT_ID || SANITY_DEFAULTS.projectId,
   dataset: import.meta.env?.VITE_SANITY_DATASET || SANITY_DEFAULTS.dataset,
   apiVersion: import.meta.env?.VITE_SANITY_API_VERSION || SANITY_DEFAULTS.apiVersion,
-  useCdn: false
+  useCdn: true
 });
 
 export const prerender = false;


### PR DESCRIPTION
## 概要

Sanity フリープランの API リクエスト上限（250k/月）超過対策。

## 変更内容

- **`src/routes/+layout.server.js`**：カテゴリ一覧の Sanity フェッチに10分インメモリキャッシュを追加。全ページ共通のレイアウトで毎回 Sanity を叩いていたのが主因だったため、ここをキャッシュするだけでリクエスト数が大幅に減少する。
- **`src/routes/rss/merkystyle.xml/+server.ts`**：`useCdn: false` → `useCdn: true` に変更。読み取り専用クライアントを CDN 経由に切り替え（CDN リクエストは API リクエストとは別枠）。

---
_Generated by [Claude Code](https://claude.ai/code/session_013WzMKBUkL381tFxpkDqoTQ)_