### PR TITLE
style: YouTubeバナーの再生バッジを拡大

### DIFF
--- a/src/lib/components/SnsFollowCard.svelte
+++ b/src/lib/components/SnsFollowCard.svelte
@@ -44,9 +44,9 @@
       rel="noopener noreferrer"
       aria-label="YouTubeでフォロー"
     >
-      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="24" height="24" aria-hidden="true">
-        <rect x="2.5" y="5" width="19" height="14" rx="4.2" fill="none" stroke="currentColor" stroke-width="2.2"/>
-        <path d="M10 9l5.8 3-5.8 3z"/>
+      <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" width="28" height="28" aria-hidden="true">
+        <rect x="1.5" y="3.5" width="21" height="17" rx="5" fill="none" stroke="currentColor" stroke-width="2.4"/>
+        <path d="M9.5 8l7.2 4-7.2 4z"/>
       </svg>
       <span>フォローする</span>
     </a>


### PR DESCRIPTION
## 概要
記事内SNS導線の **YouTube** バナーの再生バッジ（白枠＋再生マーク）を拡大し、他SNSと並んだ際により目立つように調整しました。

## 変更内容
- バッジの角丸長方形を viewBox 全体に近づけて拡大（`19×14` → `21×17`）
- アイコンの表示サイズを `24px` → `28px` に拡大
- 再生マーク（三角形）もバッジに合わせて拡大

YouTube以外（X・Facebook・Threads・TikTok・Instagram）は変更ありません。

## 表示確認
- PC幅・スマホ幅の両方でレンダリングし、バッジが大きく見やすくなったことを確認済みです。

https://claude.ai/code/session_01W3mqqS3d8Pj4qiPQPvjX5W

---
_Generated by [Claude Code](https://claude.ai/code/session_01W3mqqS3d8Pj4qiPQPvjX5W)_