### PR TITLE
fix: インフィード広告の未配信時にラッパーごと折りたたむ（Codex指摘対応）

### DIFF
--- a/src/lib/components/ArticleFeed.svelte
+++ b/src/lib/components/ArticleFeed.svelte
@@ -52,6 +52,16 @@
   }
 
   /*
+   * 広告が未配信(unfilled)のときはラッパーごと折りたたむ。
+   * AdSense.svelte が非表示にするのは内側の .adsense-container のみのため、
+   * ラッパー .feed-ad をグリッドから外さないと、広告が消えても記事3枚ごとに
+   * グリッドの行ギャップ分の余分な空白が一覧へ残ってしまう。
+   */
+  .feed-ad:has(:global(ins.adsbygoogle[data-ad-status='unfilled'])) {
+    display: none;
+  }
+
+  /*
    * SP（モバイル）のみ表示。
    * PC・タブレット幅では display:none にする。
    * display:none の要素は IntersectionObserver が交差を検知しないため、


### PR DESCRIPTION
## 概要

PR #564 への Codex レビュー指摘（P2: 未配信時は広告行ごと折りたたむ）への対応です。

## 問題

`ArticleFeed.svelte` では広告を `<div class="feed-ad">` でラップしているが、`AdSense.svelte` が未配信(unfilled)時に `display:none` にするのは内側の `.adsense-container` のみ。外側のラッパー `.feed-ad` はグリッドアイテムとして残るため、**広告が消えても CSS Grid の行ギャップ（gap: 20px）が記事3枚ごとに残り、一覧へ不自然な空白が挿入される**。

## 修正

ラッパー `.feed-ad` 自体を未配信時に折りたたむCSSルールを追加：

```css
.feed-ad:has(:global(ins.adsbygoogle[data-ad-status='unfilled'])) {
  display: none;
}
```

`.feed-ad` がグリッドから外れるため、行・ギャップごと消えて余分な空白が解消される。`:global()` により内側 `<ins>`（子コンポーネント内の要素）へ正しくマッチする。

## テスト

- `pnpm run build` 通過
- コンパイル後CSSで `.feed-ad...:has(ins.adsbygoogle[data-ad-status=unfilled]){display:none}` の出力を確認済み


---
_Generated by [Claude Code](https://claude.ai/code/session_01CcKz3qkXYmEzpnZ2wstQcd)_