### PR TITLE
カテゴリ: ハンバーガーメニューを全カテゴリ動的化・グロナビを指定順に再構成

### DIFF
--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -1,32 +1,87 @@
 // src/routes/+layout.server.js
-import { client } from '$lib/sanity/client';
+import { client, shouldSkipSanityFetch } from '$lib/sanity.server.js';
+import {
+  CATEGORY_DRAFT_FILTER,
+  QUIZ_PUBLISHED_FILTER
+} from '$lib/queries/quizVisibility.js';
+import { getQuizStubCategories } from '$lib/server/quiz-stub.js';
 
-const MENU_ITEMS = [
+// グローバルナビ（TOPページ等の水平タブ）に表示するカテゴリの並び順。
+// 左から順に表示する。slug は Sanity のカテゴリ title でマッチングして解決するため、
+// ここの slug はあくまで Sanity 取得に失敗した場合のフォールバック値。
+const GLOBAL_NAV_CATEGORIES = [
   { title: 'マッチ棒クイズ', slug: 'matchstick-quiz' },
-  { title: '読解クイズ', slug: 'reading-quiz' }
+  { title: '難読漢字', slug: 'nandoku-kanji' },
+  { title: '計算クイズ', slug: 'arithmetic-quiz' },
+  { title: 'クロスワード', slug: 'crossword' },
+  { title: '数式パズル', slug: 'formula-puzzle' }
 ];
 
-const CATEGORY_QUERY = `*[_type == "category"]{title, "slug": slug.current}`;
+// 公開クイズを1件以上持つ全カテゴリを取得する（空カテゴリはメニューに出さない）。
+const CATEGORIES_QUERY = /* groq */ `
+*[
+  _type == "category"
+  && defined(slug.current)
+  ${CATEGORY_DRAFT_FILTER}
+] | order(title asc) {
+  title,
+  "slug": slug.current,
+  "quizCount": count(*[
+    _type == "quiz"
+    && defined(slug.current)
+    && defined(category._ref)
+    && category->slug.current == ^.slug
+    ${QUIZ_PUBLISHED_FILTER}
+  ])
+}`;
+
 const CACHE_TTL = 10 * 60 * 1000; // 10分
 
 // サーバーインスタンス内で Sanity へのリクエストを10分に1回に抑えるキャッシュ
 let _cache = null;
 
-// url に依存すると全クライアント遷移でこの load が再実行され、
-// ナビゲーションごとに余計なサーバーリクエストが1本走るため、url は参照しない。
+/**
+ * グローバルナビ用に、指定順のカテゴリを Sanity 実データへ突き合わせて解決する。
+ * title が一致するカテゴリがあればその実 slug を使い、無ければフォールバック slug を使う。
+ */
+const resolveGlobalNav = (allCategories) => {
+  const byTitle = new Map(
+    (Array.isArray(allCategories) ? allCategories : []).map((c) => [c.title, c])
+  );
+  return GLOBAL_NAV_CATEGORIES.map((item) => {
+    const matched = byTitle.get(item.title);
+    return {
+      title: item.title,
+      slug: matched?.slug ?? item.slug
+    };
+  });
+};
+
 export const load = async () => {
-  const now = Date.now();
-  if (!_cache || now - _cache.ts > CACHE_TTL) {
-    const sanityCategories = await client.fetch(CATEGORY_QUERY).catch(() => []);
-    _cache = { data: sanityCategories, ts: now };
+  // Sanity をスキップする環境（ローカル/テスト）ではスタブのカテゴリを使う
+  if (shouldSkipSanityFetch()) {
+    const categories = getQuizStubCategories();
+    return {
+      categories,
+      globalNav: resolveGlobalNav(categories)
+    };
   }
 
-  const categories = MENU_ITEMS.map(item => {
-    const found = _cache.data.find(c => c.slug === item.slug);
-    return found || item;
-  });
+  const now = Date.now();
+  if (!_cache || now - _cache.ts > CACHE_TTL) {
+    const fetched = await client.fetch(CATEGORIES_QUERY).catch(() => []);
+    const list = Array.isArray(fetched) ? fetched : [];
+    // 公開クイズを持つカテゴリのみをメニューに掲載する
+    const withQuizzes = list.filter((c) => c?.slug && (c.quizCount ?? 0) > 0);
+    _cache = { data: withQuizzes, ts: now };
+  }
+
+  const categories = _cache.data;
 
   return {
+    // ハンバーガーメニュー用: 公開クイズを持つ全カテゴリ（title昇順）
     categories,
+    // グローバルナビ用: 指定順の5カテゴリ（実データで slug を解決）
+    globalNav: resolveGlobalNav(categories)
   };
 };

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -269,14 +269,10 @@
         <p class="menu-section-heading">カテゴリ</p>
         <ul class="menu-list">
           {#if data?.categories?.length}
-            {#each data.categories as c}
+            {#each data.categories as c (c.slug)}
               <li><a href="/category/{c.slug}" on:click={closeMenu}>{c.title}</a></li>
             {/each}
           {/if}
-          <li><a href="/category/kanji-quiz" on:click={closeMenu}>難読漢字</a></li>
-          <li><a href="/category/business-manner" on:click={closeMenu}>ビジネスマナー</a></li>
-          <li><a href="/category/number-quiz" on:click={closeMenu}>数字クイズ</a></li>
-          <li><a href="/category/pc-skill-quiz" on:click={closeMenu}>PCスキルクイズ</a></li>
         </ul>
       </nav>
 
@@ -296,31 +292,17 @@
   </div>
 {/if}
 
-{#if !ui.hideGlobalNavTabs}
+{#if !ui.hideGlobalNavTabs && data?.globalNav?.length}
   <nav class="main-nav">
     <div class="nav-container">
       <ul class="nav-menu">
-        {#if data?.categories?.length}
-          {#each data.categories.filter(c => c.title !== '読解クイズ') as c}
-            <li>
-              <a href={`/category/${c.slug}`} class="nav-link" data-sveltekit-preload-data
-                >{c.title}</a
-              >
-            </li>
-          {/each}
-        {/if}
-        <li>
-          <a href="/category/kanji-quiz" class="nav-link" data-sveltekit-preload-data>難読漢字</a>
-        </li>
-        <li>
-          <a href="/category/business-manner" class="nav-link" data-sveltekit-preload-data>ビジネスマナー</a>
-        </li>
-        <li>
-          <a href="/category/number-quiz" class="nav-link" data-sveltekit-preload-data>数字クイズ</a>
-        </li>
-        <li>
-          <a href="/category/pc-skill-quiz" class="nav-link" data-sveltekit-preload-data>PCスキルクイズ</a>
-        </li>
+        {#each data.globalNav as c (c.title)}
+          <li>
+            <a href={`/category/${c.slug}`} class="nav-link" data-sveltekit-preload-data
+              >{c.title}</a
+            >
+          </li>
+        {/each}
       </ul>
     </div>
   </nav>


### PR DESCRIPTION
## 概要

ハンバーガーメニューのカテゴリ一覧を「公開クイズを持つ全カテゴリ」の動的表示に変更し、TOPページのグローバルナビを指定順に再構成しました。

## 変更内容

### 1. ハンバーガーメニュー: 全カテゴリを動的表示
- `+layout.server.js`: 公開クイズを1件以上持つ全カテゴリを Sanity から取得（`title` 昇順）。従来のホワイトリスト4件ハードコード（難読漢字・ビジネスマナー・数字クイズ・PCスキルクイズ）を廃止
- `+layout.svelte`: メニューのカテゴリ項目を `data.categories` で動的レンダリング。新カテゴリを Sanity で公開すれば自動的にメニューへ反映される
- 空カテゴリ（公開クイズ0件）はメニューに出さない

### 2. グローバルナビ: 指定順に再構成
左から **マッチ棒クイズ → 難読漢字 → 計算クイズ → クロスワード → 数式パズル** の順で表示。

### 3. カテゴリページ
動的ルート `/category/[slug]` が全カテゴリのページを描画するため、**新規ページの追加は不要**です。5カテゴリすべてが 200 応答することを確認済み。

## 設計上のポイント（slug解決）

グローバルナビの各リンクは、**Sanity のカテゴリ `title` と照合して実際の slug を解決**します（コード内のハードコード slug は Sanity 取得失敗時のフォールバック）。これにより、実データのスラッグが常に自動反映され、slug の食い違いによるリンク切れを防ぎます。

> ⚠️ 前提: グロナビ5項目は Sanity のカテゴリ `title` が「マッチ棒クイズ」「難読漢字」「計算クイズ」「クロスワード」「数式パズル」と**完全一致**することを想定しています。title が異なるカテゴリはフォールバック slug（`matchstick-quiz` / `nandoku-kanji` / `arithmetic-quiz` / `crossword` / `formula-puzzle`）が使われます。デプロイ後にグロナビの各リンクが正しいカテゴリページに飛ぶかご確認ください。

## 検証

- `SKIP_SANITY=1 pnpm build` 成功
- スタブ環境のプレビューで確認:
  - グロナビが指定順（マッチ棒クイズ→難読漢字→計算クイズ→クロスワード→数式パズル）で描画
  - `title` 照合が機能（スタブの「マッチ棒クイズ」→ stub slug `matchstick` に解決）
  - 5カテゴリ全ページが 200 応答

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hr81aNw38JNvz8jXF6ZEA

---
_Generated by [Claude Code](https://claude.ai/code/session_019hr81aNw38JNvz8jXF6ZEA)_