### PR TITLE
fix(カテゴリ): メニューが空になる不具合を修正・グロナビのslug解決を堅牢化

### DIFF
--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -18,6 +18,18 @@ const GLOBAL_NAV_CATEGORIES = [
   { title: '数式パズル', slug: 'formula-puzzle' }
 ];
 
+// Sanity 取得が失敗（一時障害・環境変数不備など）したときに使う静的フォールバック。
+// 取得成功時は使われない。メニューが空になる事故を防ぐための最低限のカテゴリ一覧。
+const FALLBACK_CATEGORIES = [
+  { title: 'マッチ棒クイズ', slug: 'matchstick-quiz' },
+  { title: '難読漢字', slug: 'kanji-quiz' },
+  { title: '計算クイズ', slug: 'arithmetic-quiz' },
+  { title: 'クロスワード', slug: 'crossword' },
+  { title: '数式パズル', slug: 'formula-puzzle' },
+  { title: 'ビジネスマナー', slug: 'business-manner' },
+  { title: '数字クイズ', slug: 'number-quiz' }
+];
+
 // 全カテゴリと、その公開クイズ数を取得する。
 // クイズ数は references(^._id) で数える（category 参照の _id 突き合わせ。
 // ^.slug のような文字列/オブジェクト不一致による数え漏れを避ける確実な方法）。
@@ -96,11 +108,26 @@ export const load = async () => {
 
   const now = Date.now();
   if (!_cache || now - _cache.ts > CACHE_TTL) {
-    const fetched = await client.fetch(CATEGORIES_QUERY).catch((err) => {
+    let data = null;
+    try {
+      const fetched = await client.fetch(CATEGORIES_QUERY);
+      const built = buildMenuCategories(fetched);
+      if (built.length > 0) data = built;
+    } catch (err) {
       console.error('[+layout.server] categories fetch failed', err);
-      return [];
-    });
-    _cache = { data: buildMenuCategories(fetched), ts: now };
+    }
+
+    if (data) {
+      // 正常取得: 通常どおりキャッシュ
+      _cache = { data, ts: now };
+    } else if (_cache?.data?.length) {
+      // 取得失敗だが直前の良いキャッシュがある: それを維持（TTLだけ更新して過剰リトライを防ぐ）
+      _cache = { data: _cache.data, ts: now };
+    } else {
+      // 取得失敗＋キャッシュ無し: 静的フォールバックを使い、メニューを空にしない。
+      // ts=0 で毎リクエスト再取得を試み、成功したら通常キャッシュに切り替える。
+      _cache = { data: FALLBACK_CATEGORIES, ts: 0 };
+    }
   }
 
   const categories = _cache.data;

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -6,18 +6,21 @@ import {
 } from '$lib/queries/quizVisibility.js';
 import { getQuizStubCategories } from '$lib/server/quiz-stub.js';
 
-// グローバルナビ（TOPページ等の水平タブ）に表示するカテゴリの並び順。
-// 左から順に表示する。slug は Sanity のカテゴリ title でマッチングして解決するため、
-// ここの slug はあくまで Sanity 取得に失敗した場合のフォールバック値。
+// グローバルナビ（TOPページ等の水平タブ）に表示するカテゴリの並び順（左→右）。
+// slug は Sanity のカテゴリ title でマッチングして実 slug に解決する。
+// pinnedSlug:true の項目は title 照合せず必ずこの slug を使う
+// （難読漢字は kanji-quiz / nandoku-kanji の2スラッグを統合する静的ルートへ固定）。
 const GLOBAL_NAV_CATEGORIES = [
   { title: 'マッチ棒クイズ', slug: 'matchstick-quiz' },
-  { title: '難読漢字', slug: 'nandoku-kanji' },
+  { title: '難読漢字', slug: 'kanji-quiz', pinnedSlug: true },
   { title: '計算クイズ', slug: 'arithmetic-quiz' },
   { title: 'クロスワード', slug: 'crossword' },
   { title: '数式パズル', slug: 'formula-puzzle' }
 ];
 
-// 公開クイズを1件以上持つ全カテゴリを取得する（空カテゴリはメニューに出さない）。
+// 全カテゴリと、その公開クイズ数を取得する。
+// クイズ数は references(^._id) で数える（category 参照の _id 突き合わせ。
+// ^.slug のような文字列/オブジェクト不一致による数え漏れを避ける確実な方法）。
 const CATEGORIES_QUERY = /* groq */ `
 *[
   _type == "category"
@@ -29,8 +32,7 @@ const CATEGORIES_QUERY = /* groq */ `
   "quizCount": count(*[
     _type == "quiz"
     && defined(slug.current)
-    && defined(category._ref)
-    && category->slug.current == ^.slug
+    && references(^._id)
     ${QUIZ_PUBLISHED_FILTER}
   ])
 }`;
@@ -42,19 +44,44 @@ let _cache = null;
 
 /**
  * グローバルナビ用に、指定順のカテゴリを Sanity 実データへ突き合わせて解決する。
- * title が一致するカテゴリがあればその実 slug を使い、無ければフォールバック slug を使う。
+ * pinnedSlug の項目は固定 slug を使い、それ以外は title が一致するカテゴリの
+ * 実 slug を使う（無ければフォールバック slug）。
  */
 const resolveGlobalNav = (allCategories) => {
   const byTitle = new Map(
     (Array.isArray(allCategories) ? allCategories : []).map((c) => [c.title, c])
   );
   return GLOBAL_NAV_CATEGORIES.map((item) => {
+    if (item.pinnedSlug) {
+      return { title: item.title, slug: item.slug };
+    }
     const matched = byTitle.get(item.title);
     return {
       title: item.title,
       slug: matched?.slug ?? item.slug
     };
   });
+};
+
+/**
+ * 重複タイトルを1件に畳んでメニュー用カテゴリ配列を作る。
+ * 公開クイズを持つカテゴリを優先し、万一すべて0件でもメニューが空にならないよう
+ * フォールバックで全カテゴリを返す（＝メニューが消える事故を防ぐ）。
+ */
+const buildMenuCategories = (list) => {
+  const valid = (Array.isArray(list) ? list : []).filter((c) => c?.slug && c?.title);
+  const withQuizzes = valid.filter((c) => (c.quizCount ?? 0) > 0);
+  const source = withQuizzes.length > 0 ? withQuizzes : valid;
+
+  // 同一タイトルの重複を排除（先勝ち）
+  const seen = new Set();
+  const deduped = [];
+  for (const c of source) {
+    if (seen.has(c.title)) continue;
+    seen.add(c.title);
+    deduped.push({ title: c.title, slug: c.slug });
+  }
+  return deduped;
 };
 
 export const load = async () => {
@@ -69,17 +96,17 @@ export const load = async () => {
 
   const now = Date.now();
   if (!_cache || now - _cache.ts > CACHE_TTL) {
-    const fetched = await client.fetch(CATEGORIES_QUERY).catch(() => []);
-    const list = Array.isArray(fetched) ? fetched : [];
-    // 公開クイズを持つカテゴリのみをメニューに掲載する
-    const withQuizzes = list.filter((c) => c?.slug && (c.quizCount ?? 0) > 0);
-    _cache = { data: withQuizzes, ts: now };
+    const fetched = await client.fetch(CATEGORIES_QUERY).catch((err) => {
+      console.error('[+layout.server] categories fetch failed', err);
+      return [];
+    });
+    _cache = { data: buildMenuCategories(fetched), ts: now };
   }
 
   const categories = _cache.data;
 
   return {
-    // ハンバーガーメニュー用: 公開クイズを持つ全カテゴリ（title昇順）
+    // ハンバーガーメニュー用: 全カテゴリ（公開クイズ優先・title昇順）
     categories,
     // グローバルナビ用: 指定順の5カテゴリ（実データで slug を解決）
     globalNav: resolveGlobalNav(categories)


### PR DESCRIPTION
## 緊急修正

#569 のマージ後、ハンバーガーメニューのカテゴリ一覧が全消失し、グロナビの難読漢字/クロスワードが0問・計算クイズが404になっていた不具合を修正します。

## 原因

`+layout.server.js` のカテゴリ数カウントで `category->slug.current == ^.slug` を使用していたが、`^.slug` がスラッグ**文字列**に解決されず（カテゴリ文書の `slug` はオブジェクト）、全カテゴリの `quizCount` が 0 に。その結果 `quizCount > 0` フィルタで**全カテゴリが除外→メニュー空**に。

メニューが空になると `data.categories` が空 → グロナビの title 照合が効かず、全項目が誤ったフォールバック slug にリンク（難読漢字→nandoku-kanji で0問 / クロスワード→crossword で0問 / 計算クイズ→arithmetic-quiz で404）。

## 修正

- **クイズ数を `references(^._id)` で数える**（カテゴリ `_id` の突き合わせ。文字列/オブジェクト不一致による数え漏れを回避）
- **メニューが空にならない防御フォールバック**を追加（公開クイズ持ちが0件なら全カテゴリを表示）。万一カウントが再び失敗してもメニューは消えない
- **重複タイトルの排除**
- **難読漢字はグロナビで `/category/kanji-quiz`（kanji-quiz + nandoku-kanji の2スラッグを統合する静的ルート）へ固定**し、0問になる問題を回避

## 検証

- `SKIP_SANITY=1 pnpm build` 成功
- スタブプレビューでグロナビが指定順（マッチ棒クイズ→難読漢字→計算クイズ→クロスワード→数式パズル）で描画、難読漢字が `/category/kanji-quiz` に固定されることを確認

> デプロイ後、グロナビの「計算クイズ」「クロスワード」「数式パズル」「マッチ棒クイズ」は Sanity のカテゴリ **title 照合**で実 slug に解決されます。これらの正確な title が Sanity と一致していれば正しいページに飛びます。デプロイ後にご確認ください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019hr81aNw38JNvz8jXF6ZEA

---
_Generated by [Claude Code](https://claude.ai/code/session_019hr81aNw38JNvz8jXF6ZEA)_