### PR TITLE
feat(rss): SmartNews/イチオシ配信フィードの上限を20→30件に拡大

### DIFF
--- a/src/lib/queries/rssSmartnews.groq.js
+++ b/src/lib/queries/rssSmartnews.groq.js
@@ -19,7 +19,7 @@ export const RSS_SMARTNEWS_QUERY = /* groq */ `
   defined(slug.current) &&
   publishedAt < now() &&
   ${EXCLUDE_NULL_TEXT_FILTER}
-] | order(publishedAt desc)[0...20]{
+] | order(publishedAt desc)[0...30]{
   _id,
   _type,
   publishedAt,


### PR DESCRIPTION
## 背景

「毎日自動生成しているマッチ棒クイズがイチオシのRSSに載っていない」との報告を調査したところ、イチオシへの配信は SmartNews 用フィード（`/feed/smartnews`／SmartNews・ママテナ・イチオシ共通）が使われており、このフィードが `[0...20]` で最大20件に絞られていたことが判明した。

毎日30件弱の記事を公開しているため、翌日公開バッファで1日遅れるマッチ棒クイズなどが新着20件枠から押し出され、配信先に載らないことがあった。

## 変更内容

- `src/lib/queries/rssSmartnews.groq.js`: 配信件数の上限を `[0...20]` → `[0...30]` に拡大。

代表RSS（merkystyle）は既に30件で運用しており、それに揃える。SmartFormat 上も件数の厳密な上限規定はない。

## 影響範囲

- `/feed/smartnews`（SmartNews・ママテナ・イチオシ共通配信）が最大30件を返すようになる。
- 広告枠クエリ（`[0...8]`）や関連記事（最大3件）は変更なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3NjSpGeChYt8ptQpBtATT)_