### PR TITLE
feat(rss): SmartNews/イチオシフィードでマッチ棒クイズを先頭固定

### DIFF
--- a/src/lib/queries/rssSmartnews.groq.js
+++ b/src/lib/queries/rssSmartnews.groq.js
@@ -19,7 +19,13 @@ export const RSS_SMARTNEWS_QUERY = /* groq */ `
   defined(slug.current) &&
   publishedAt < now() &&
   ${EXCLUDE_NULL_TEXT_FILTER}
-] | order(publishedAt desc)[0...30]{
+]
+// マッチ棒クイズを必ずフィード先頭に固定する。
+// 配信先（SmartNews/ママテナ/イチオシ）が「上位N件のみ取り込む」挙動でも、
+// マッチ棒が取り込み枠から漏れないようにするため。マッチ棒のスラッグは
+// 必ず "matchstick-quiz/..." で始まるので、それを 0（先頭）に寄せる。
+// 同一グループ内は従来どおり公開日の新しい順。全体上限は30件。
+| order(select(string::startsWith(slug.current, "matchstick-quiz/") => 0, 1) asc, publishedAt desc)[0...30]{
   _id,
   _type,
   publishedAt,


### PR DESCRIPTION
## 背景

イチオシ（SmartNews/ママテナと共通のRSS配信先）は、フィードに30件配信していても取り込むのは日に9〜12件程度で、配信先が「上位N件のみ取り込む」挙動と考えられる。マッチ棒クイズを確実に連携させたいという要望に対応する。

## 変更内容

- `src/lib/queries/rssSmartnews.groq.js`: フィードの並び順を変更し、**マッチ棒クイズ（スラッグが `matchstick-quiz/` で始まる記事）を必ず先頭**に寄せる。
  - `order(select(string::startsWith(slug.current, "matchstick-quiz/") => 0, 1) asc, publishedAt desc)`
  - 同一グループ内は従来どおり公開日の新しい順。全体上限は30件のまま。

これにより、取り込み枠が小さくてもマッチ棒が先頭から取り込まれ、枠落ちしにくくなる。

## 補足（本PRの範囲外・取り込み側依存）

- **再配信（再公開）記事**は、配信先が既取り込みURLを重複としてスキップする場合、並び順を変えても再取り込みされない可能性がある（配信先仕様依存）。
- **新規マッチ棒は「翌日公開」**のため、生成当日はフィード条件（`publishedAt < now()`）を満たさず、翌日から先頭に載る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01N3NjSpGeChYt8ptQpBtATT)_