### PR TITLE
feat(可視性): 記事の非公開化(reviewStatus)を全経路に適用し410 Goneを返す

### DIFF
--- a/src/lib/queries/quizVisibility.js
+++ b/src/lib/queries/quizVisibility.js
@@ -13,12 +13,68 @@ export const shouldRestrictToPublishedContent = !previewDraftsEnabled;
 
 export const QUIZ_PUBLISHED_FIELD = 'coalesce(publishedAt, _createdAt)';
 
-export const QUIZ_PUBLISHED_FILTER = shouldRestrictToPublishedContent
-  ? `
+/**
+ * 公開してよい記事だけを通す条件（先頭に && を持たない素の式）。
+ *
+ * 「retracted を除外する」拒否リストではなく「approved だけを通す」許可リストにしている。
+ * これにより needs_review（監査待ち）も自動的に非公開となり、将来ステータスを
+ * 追加したときも既定で安全側（出さない）に倒れる。
+ *
+ * reviewStatus 未設定の既存記事は "approved" とみなす（coalesce で既定値を与える）。
+ * GROQ では null との比較結果が直感に反する場合があるため、必ず coalesce を挟む。
+ */
+export const QUIZ_NOT_RETRACTED_CONDITION = /* groq */ `coalesce(reviewStatus, "approved") == "approved"`;
+
+/**
+ * 公開審査フィルタ。プレビュー（ドラフト表示）の有無に関わらず**常に**適用する。
+ *
+ * 是正対象の記事は編集者向けプレビューであっても公開経路に出してはならない。
+ * 内容の確認は Sanity Studio 上で行う。
+ */
+export const QUIZ_RETRACTED_FILTER = `
+  && ${QUIZ_NOT_RETRACTED_CONDITION}`;
+
+/**
+ * 本文に「null」が表示される（生成バグ）記事を除外するフィルタ。
+ * 例：「11からnullは差が5」「6+7+null=15」のように、数値が埋まらず "null" が残ったもの。
+ * ※ Sanity 側の本文を修正すれば該当しなくなり、自動的に復帰する（self-healing）。
+ *
+ * 以前は SmartNews フィード専用だったが、サイト本体・sitemap・他フィードにも
+ * 適用するため、共通の可視性判定としてここへ集約した。
+ */
+export const EXCLUDE_NULL_TEXT_FILTER = /* groq */ `!(
+  pt::text(problemDescription) match "*null*" ||
+  pt::text(hints) match "*null*" ||
+  pt::text(answerExplanation) match "*null*" ||
+  pt::text(closingMessage) match "*null*" ||
+  pt::text(body) match "*null*"
+)`;
+
+export const QUIZ_PUBLISHED_FILTER =
+  (shouldRestrictToPublishedContent
+    ? `
   && !(_id in path("drafts.**"))
   && defined(${QUIZ_PUBLISHED_FIELD})
   && ${QUIZ_PUBLISHED_FIELD} <= now()`
-  : '';
+    : '') + QUIZ_RETRACTED_FILTER;
+
+/**
+ * 外部配信フィード（SmartNews / Merkystyle / TRILL）向けの最も厳しいゲート。
+ * 公開判定＋非公開化除外に加えて、本文の生成バグ記事も落とす。
+ */
+export const QUIZ_FEED_SAFE_FILTER = `${QUIZ_PUBLISHED_FILTER}
+  && ${EXCLUDE_NULL_TEXT_FILTER}`;
+
+/**
+ * スラッグから「存在するが非公開化されている」記事を引くクエリ。
+ * 詳細ページで 404 と 410 Gone を出し分けるために使う。
+ */
+export const QUIZ_RETRACTED_LOOKUP = /* groq */ `*[
+  _type == "quiz"
+  && slug.current == $slug
+  && !(_id in path("drafts.**"))
+  && coalesce(reviewStatus, "approved") == "retracted"
+][0]{ _id, retractedReason }`;
 
 export const QUIZ_ORDER_BY_PUBLISHED = `${QUIZ_PUBLISHED_FIELD} desc`;
 
@@ -42,6 +98,11 @@ export const filterVisibleQuizzes = (items) => {
   return items.reduce((acc, originalQuiz) => {
     const slug = toSlugString(originalQuiz);
     if (!slug) return acc;
+
+    // 公開可でない記事はここでも落とす。クエリ側の除外が漏れた場合の最終防波堤。
+    // （reviewStatus を select していないクエリでは undefined になり、素通りする）
+    const reviewStatus = originalQuiz?.reviewStatus;
+    if (reviewStatus != null && reviewStatus !== 'approved') return acc;
 
     const baseQuiz =
       slug && typeof originalQuiz.slug !== 'string' ? { ...originalQuiz, slug } : originalQuiz;

--- a/src/lib/queries/rssMerkystyle.groq.js
+++ b/src/lib/queries/rssMerkystyle.groq.js
@@ -1,12 +1,18 @@
 // src/lib/queries/rssMerkystyle.groq.js
+import {
+  EXCLUDE_NULL_TEXT_FILTER,
+  QUIZ_NOT_RETRACTED_CONDITION,
+} from '$lib/queries/quizVisibility.js';
 
 const PUBLISHED_DATETIME_FIELD = 'coalesce(publishedAt, _createdAt)';
 
-// 公開判定（ドラフト除外＆公開日時チェック）
+// 公開判定（ドラフト除外＆公開日時チェック＆是正対象除外＆生成バグ記事除外）
 const PUBLISHED_FILTER = `
   defined(slug.current) &&
   !(_id in path("drafts.**")) &&
-  ${PUBLISHED_DATETIME_FIELD} <= now()
+  ${PUBLISHED_DATETIME_FIELD} <= now() &&
+  ${QUIZ_NOT_RETRACTED_CONDITION} &&
+  ${EXCLUDE_NULL_TEXT_FILTER}
 `;
 
 export const RSS_MERKYSTYLE_QUERY = /* groq */ `

--- a/src/lib/queries/rssSmartnews.groq.js
+++ b/src/lib/queries/rssSmartnews.groq.js
@@ -1,15 +1,11 @@
 // src/lib/queries/rssSmartnews.groq.js
+import {
+  EXCLUDE_NULL_TEXT_FILTER,
+  QUIZ_NOT_RETRACTED_CONDITION,
+} from '$lib/queries/quizVisibility.js';
 
-// 本文に「null」が表示される（生成バグ）記事をフィードから除外するフィルタ。
-// 例：「11からnullは差が5」「6+7+null=15」のように、数値が埋まらず "null" が残ったもの。
-// ※ Sanity 側の本文を修正すれば該当しなくなり、自動的にフィードへ復帰する（self-healing）。
-export const EXCLUDE_NULL_TEXT_FILTER = /* groq */ `!(
-  pt::text(problemDescription) match "*null*" ||
-  pt::text(hints) match "*null*" ||
-  pt::text(answerExplanation) match "*null*" ||
-  pt::text(closingMessage) match "*null*" ||
-  pt::text(body) match "*null*"
-)`;
+// 本文の「null」除外フィルタと是正対象の除外条件は quizVisibility.js に集約した
+// （サイト本体・sitemap・他フィードにも同じ判定を適用するため）。
 
 // 公開済みの記事のみを取得するクエリ
 export const RSS_SMARTNEWS_QUERY = /* groq */ `
@@ -18,6 +14,7 @@ export const RSS_SMARTNEWS_QUERY = /* groq */ `
   !(_id in path("drafts.**")) &&
   defined(slug.current) &&
   publishedAt < now() &&
+  ${QUIZ_NOT_RETRACTED_CONDITION} &&
   ${EXCLUDE_NULL_TEXT_FILTER}
 ]
 // マッチ棒クイズを必ずフィード先頭に固定する。
@@ -65,6 +62,7 @@ export const RSS_SMARTNEWS_QUERY = /* groq */ `
     publishedAt < now() &&
     _id != ^._id && // 自分自身を除外
     category._ref == ^.category._ref && // 同じカテゴリ (展開前の参照IDと比較)
+    ${QUIZ_NOT_RETRACTED_CONDITION} && // 是正対象の記事は関連記事からも除外
     ${EXCLUDE_NULL_TEXT_FILTER} // 本文に "null" が出る記事は関連記事からも除外
   ] | order(publishedAt desc)[0...3]{
     title,

--- a/src/lib/queries/rssTrill.groq.js
+++ b/src/lib/queries/rssTrill.groq.js
@@ -1,12 +1,19 @@
 // src/lib/queries/rssTrill.groq.js
 // rssMerkystyle.groq.js と同じ構造で記述（動作確認済み構文を踏襲）
 
+import {
+  EXCLUDE_NULL_TEXT_FILTER,
+  QUIZ_NOT_RETRACTED_CONDITION,
+} from '$lib/queries/quizVisibility.js';
+
 const PUBLISHED_DATETIME_FIELD = 'coalesce(publishedAt, _createdAt)';
 
 const PUBLISHED_FILTER = `
   defined(slug.current) &&
   !(_id in path("drafts.**")) &&
-  ${PUBLISHED_DATETIME_FIELD} <= now()
+  ${PUBLISHED_DATETIME_FIELD} <= now() &&
+  ${QUIZ_NOT_RETRACTED_CONDITION} &&
+  ${EXCLUDE_NULL_TEXT_FILTER}
 `;
 
 export const RSS_TRILL_QUERY = /* groq */ `

--- a/src/lib/server/retracted.js
+++ b/src/lib/server/retracted.js
@@ -1,0 +1,36 @@
+/**
+ * 是正対象として非公開化された記事に 410 Gone を返すためのヘルパー。
+ *
+ * 404（Not Found）ではなく 410（Gone）を返す理由:
+ * 404 は「一時的に見つからない」とも解釈されるためクローラは再訪を続けるが、
+ * 410 は「恒久的に削除された」という明示的なシグナルで、Google / SmartNews とも
+ * インデックスからの除去が速く、再クロールも止まる。
+ * 是正対象の記事を配信先の目に触れさせないことが目的なので 410 を使う。
+ */
+
+import { error } from '@sveltejs/kit';
+import { client } from '$lib/sanity.server.js';
+import { QUIZ_RETRACTED_LOOKUP } from '$lib/queries/quizVisibility.js';
+
+/**
+ * 公開クエリが 0 件だったスラッグについて、非公開化されたものか単に存在しないのかを判定し、
+ * 前者なら 410、後者なら 404 を投げる。**必ず例外を投げて戻らない。**
+ *
+ * @param {string} slug 記事スラッグ（slug.current）
+ * @returns {Promise<never>}
+ */
+export async function throwGoneOrNotFound(slug) {
+  let retracted = null;
+  try {
+    retracted = await client.fetch(QUIZ_RETRACTED_LOOKUP, { slug });
+  } catch (err) {
+    // 判定用クエリの失敗で 503 にはしない。通常の 404 として扱う。
+    console.error('[retracted] lookup failed:', err);
+  }
+
+  if (retracted?._id) {
+    throw error(410, 'この記事は内容の見直しのため公開を終了しました。');
+  }
+
+  throw error(404, `Quiz not found: ${slug}`);
+}

--- a/src/routes/api/update-related/+server.js
+++ b/src/routes/api/update-related/+server.js
@@ -17,11 +17,14 @@ import { createClient } from '@sanity/client';
 
 const WEBHOOK_SECRET = env.SANITY_REVALIDATE_SECRET || env.VERCEL_REVALIDATE_TOKEN || '';
 
-// 全公開済み quiz を publishedAt 降順で取得（再公開記事を除外）
+// 全公開済み quiz を publishedAt 降順で取得（再公開記事・是正対象記事を除外）
+// 是正対象を除外しないと、非公開記事への relatedArticles 参照が生成され、
+// JSON-LD の relatedLink と内部リンクが 410 のページを指してしまう。
 const ALL_QUIZ_QUERY = /* groq */ `*[
   _type == "quiz" &&
   !(_id in path("drafts.**")) &&
-  isRepublished != true
+  isRepublished != true &&
+  coalesce(reviewStatus, "approved") != "retracted"
 ] | order(publishedAt desc) {
   _id,
   "slug": slug.current,

--- a/src/routes/category/[categorySlug]/[quizSlug]/+page.server.js
+++ b/src/routes/category/[categorySlug]/[quizSlug]/+page.server.js
@@ -13,6 +13,7 @@ import { createPageSeo, portableTextToPlain, resolveQuizOgImage } from '$lib/seo
 import { SITE } from '$lib/config/site.js';
 import { fetchRelatedQuizzes } from '$lib/server/related-quizzes.js';
 import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
+import { throwGoneOrNotFound } from '$lib/server/retracted.js';
 import { ensurePublishedAt, resolvePublishedDate } from '$lib/utils/publishedDate.js';
 
 export const prerender = false;
@@ -118,7 +119,8 @@ export async function load({ params, setHeaders }) {
     throw error(503, 'データ取得に失敗しました。しばらくしてから再度お試しください。');
   }
 
-  if (!doc) throw error(404, `Quiz not found: ${quizSlug}`);
+  // 非公開化された記事は 410 Gone、本当に存在しない場合のみ 404
+  if (!doc) await throwGoneOrNotFound(quizSlug);
 
   const normalizedDoc = ensurePublishedAt(doc, doc?._id ?? quizSlug);
 

--- a/src/routes/feed/smartnews/+server.js
+++ b/src/routes/feed/smartnews/+server.js
@@ -1,8 +1,8 @@
 import { client } from '$lib/sanity.server.js';
 import { urlFor } from '$lib/sanity/client';
-import { RSS_SMARTNEWS_QUERY, EXCLUDE_NULL_TEXT_FILTER } from '$lib/queries/rssSmartnews.groq';
+import { RSS_SMARTNEWS_QUERY } from '$lib/queries/rssSmartnews.groq';
 import { portableTextToHtml } from '$lib/utils/portableText';
-import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
+import { QUIZ_FEED_SAFE_FILTER } from '$lib/queries/quizVisibility.js';
 
 const siteTitle = '脳トレ日和';
 const siteLink = 'https://noutorebiyori.com/';
@@ -10,8 +10,9 @@ const siteDescription =
 	'脳トレ日和は、間違い探しや計算問題などの脳トレクイズを通じて、毎日の習慣づくりをサポートする無料のWebメディアです。高齢者の方でも安心して楽しめるシンプルな操作性と見やすいデザインが特徴です。';
 const siteLogo = 'https://noutorebiyori.com/logo.png';
 
-// 最新クイズリスト（広告枠用）。本文に "null" が出る記事は広告リンクからも除外する。
-const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_PUBLISHED_FILTER} && ${EXCLUDE_NULL_TEXT_FILTER}] | order(publishedAt desc)[0...8]{
+// 最新クイズリスト（広告枠用）。
+// 是正対象（reviewStatus）と本文に "null" が出る記事は広告リンクからも除外する。
+const globalLatestQuizzesQuery = /* groq */ `*[_type == "quiz" ${QUIZ_FEED_SAFE_FILTER}] | order(publishedAt desc)[0...8]{
   title,
   "slug": slug.current,
   "categorySlug": category->slug.current,

--- a/src/routes/quiz/[...slug]/+page.server.js
+++ b/src/routes/quiz/[...slug]/+page.server.js
@@ -1,10 +1,11 @@
 import { env } from '$env/dynamic/private';
-import { error, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { createSlugContext, findQuizDocument } from '$lib/server/quiz.js';
 import { createPageSeo, portableTextToPlain, resolveQuizOgImage } from '$lib/seo.js';
 import { SITE } from '$lib/config/site.js';
 import { fetchRelatedQuizzes } from '$lib/server/related-quizzes.js';
 import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
+import { throwGoneOrNotFound } from '$lib/server/retracted.js';
 import { ensurePublishedAt, resolvePublishedDate } from '$lib/utils/publishedDate.js';
 
 export const prerender = false;
@@ -95,7 +96,8 @@ export async function load({ params, setHeaders }) {
     query: Q,
     logPrefix: 'quiz/[...slug]'
   });
-  if (!doc) throw error(404, `Quiz not found: ${slug}`);
+  // 非公開化された記事は 410 Gone、本当に存在しない場合のみ 404
+  if (!doc) await throwGoneOrNotFound(slug);
   const normalizedDoc = ensurePublishedAt(doc, doc?._id ?? slug);
 
   // スラッグ正規化リダイレクト

--- a/src/routes/quiz/[...slug]/answer/+page.server.js
+++ b/src/routes/quiz/[...slug]/answer/+page.server.js
@@ -1,7 +1,8 @@
-import { error, redirect } from '@sveltejs/kit';
+import { redirect } from '@sveltejs/kit';
 import { createSlugContext, findQuizDocument } from '$lib/server/quiz.js';
 import { fetchRelatedQuizzes } from '$lib/server/related-quizzes.js';
 import { QUIZ_PUBLISHED_FILTER } from '$lib/queries/quizVisibility.js';
+import { throwGoneOrNotFound } from '$lib/server/retracted.js';
 import { createPageSeo, portableTextToPlain, resolveQuizOgImage } from '$lib/seo.js';
 import { SITE } from '$lib/config/site.js';
 import { resolvePublishedDate } from '$lib/utils/publishedDate.js';
@@ -45,7 +46,8 @@ export async function load({ params, setHeaders }) {
     query: Q,
     logPrefix: 'quiz/[...slug]/answer'
   });
-  if (!quiz) throw error(404, 'Answer not found');
+  // 非公開化された記事は 410 Gone、本当に存在しない場合のみ 404
+  if (!quiz) await throwGoneOrNotFound(slug);
   if (typeof quiz.slug === 'string' && quiz.slug !== slug) {
     throw redirect(308, `/quiz/${quiz.slug}/answer`);
   }

--- a/studio/schemas/quiz.js
+++ b/studio/schemas/quiz.js
@@ -357,6 +357,48 @@ export default defineType({
       initialValue: false,
     }),
 
+    // ── 公開審査ステータス ─────────────────
+    // 「非公開化」を実現するための単一の判定軸。
+    // publishedAt は日付でしか制御できず記事を隠せないため、この項目で明示的に制御する。
+    // retracted にすると、サイト・カテゴリ一覧・sitemap・RSS(SmartNews/Merkystyle/TRILL)・
+    // 関連記事・毎日の再公開バッチのすべてから即座に除外され、記事URLは 410 Gone を返す。
+    defineField({
+      name: 'reviewStatus',
+      title: '公開審査ステータス',
+      description:
+        '「非公開（是正対象）」にすると、サイト・配信フィード・sitemap の全経路から除外され、記事URLは 410 Gone を返します。記事データは削除されないため、修正後に「公開可」へ戻せば復帰します。',
+      type: 'string',
+      group: 'publish',
+      options: {
+        list: [
+          { title: '✅ 公開可', value: 'approved' },
+          { title: '🕒 要確認（サイトには出ません）', value: 'needs_review' },
+          { title: '🚫 非公開（是正対象）', value: 'retracted' }
+        ],
+        layout: 'radio'
+      },
+      initialValue: 'approved'
+    }),
+    defineField({
+      name: 'retractedReason',
+      title: '非公開の理由',
+      description:
+        '監査で検出した不備の内容を記録します（例: 別解あり 14-6=8 / 14-8=6、画像と本文の不一致）。SmartNews への説明資料の根拠になるため、具体的に残してください。',
+      type: 'text',
+      rows: 2,
+      group: 'publish',
+      hidden: ({ document }) =>
+        document?.reviewStatus !== 'retracted' && document?.reviewStatus !== 'needs_review'
+    }),
+    defineField({
+      name: 'retractedAt',
+      title: '非公開にした日時',
+      type: 'datetime',
+      group: 'publish',
+      readOnly: true,
+      hidden: ({ document }) => !document?.retractedAt
+    }),
+
     // ── クイズ種別 ───────────────────────
     defineField({
       name: 'quizType',


### PR DESCRIPTION
## 目的

SmartNews 再申請対応の基盤整備（Step 0-b）。

従来、記事の公開判定は `publishedAt <= now()` のみで、**是正対象の記事を非公開にする手段が存在しませんでした**。監査で不備を見つけても消す先がない状態だったため、まず「非公開にできる」土台を作ります。

## 変更内容

### 1. スキーマに公開審査ステータスを追加（`studio/schemas/quiz.js`）

`reviewStatus`（`approved` / `needs_review` / `retracted`）、`retractedReason`、`retractedAt` を「公開設定」タブに追加。

`retractedReason` は監査で検出した不備の内容を記録するもので、SmartNews へ提出するチェック体制の説明資料の根拠になります。

### 2. 判定を「許可リスト方式」に（`src/lib/queries/quizVisibility.js`）

```groq
coalesce(reviewStatus, "approved") == "approved"
```

「`retracted` を除外する」拒否リストではなく「`approved` だけを通す」許可リストにしています。理由は2つです。

- `needs_review`（監査待ち）が自動的に非公開になり、生成時ゲートで「検証NGの記事を needs_review で入稿する」設計がそのまま機能する
- 将来ステータスを追加したときも既定で安全側（出さない）に倒れる

`reviewStatus` 未設定の既存記事は `coalesce` で `approved` 扱いのため、**現行の表示は一切変わりません**。

### 3. 適用範囲

`QUIZ_PUBLISHED_FILTER` が既に22箇所で使われる集約点だったため、そこに組み込むことで一覧・詳細・カテゴリ・トップ・sitemap が一括で対応。加えて独自の公開判定を持っていた箇所を個別に対応しました。

- RSS 3種（SmartNews / Merkystyle / TRILL）
- `update-related` API — 非公開記事への `relatedArticles` 参照と JSON-LD `relatedLink` の生成を防止
- `filterVisibleQuizzes` に実行時ガード（クエリ側の除外が漏れた場合の最終防波堤）

プレビュー（ドラフト表示）が有効な場合も常に適用します。是正対象は編集者向けプレビューであっても公開経路に出すべきではなく、内容確認は Studio 上で行うためです。

### 4. 本文 null フィルタの共通化

本文に `null` が残る生成バグ記事の除外は SmartNews フィード専用でしたが、`quizVisibility.js` へ集約し他の2フィードにも適用しました。フィード用ゲートとして `QUIZ_FEED_SAFE_FILTER` を用意しています。

### 5. 410 Gone（`src/lib/server/retracted.js` 新規）

非公開記事の詳細ページ・解答ページは 404 ではなく **410 Gone** を返します。404 は「一時的に見つからない」とも解釈されクローラが再訪を続けますが、410 は恒久削除の明示的なシグナルで、Google / SmartNews のインデックスからの除去が速く再クロールも止まります。

存在しない記事は従来どおり 404 で、両者を出し分けています。判定用クエリが失敗した場合は 404 にフォールバックし、503 でページを壊しません。

## 動作への影響

既存記事はすべて `reviewStatus` 未設定 → `approved` 扱いになるため、**このマージ時点で表示が変わる記事はありません**。実際の非公開化は、監査で対象を確定させてから別途行います。

## 検証

- `SKIP_SANITY=1 pnpm build` 成功
- 合成後の GROQ を実ソース評価で確認し、構文の正しさを検証
- 変更で崩れた prettier 整形3ファイルを修正

既知の未解決事項として、`pnpm test` が1件失敗しますが、**本変更を退避しても同じ 503 で失敗する**ため、検証環境が Sanity に到達できないことによる既存の失敗です。prettier も5ファイルが変更前から警告状態ですが、無関係な差分を増やさないため触っていません。

## マージ後に必要な作業

Studio のスキーマ変更を反映するには **Studio の再デプロイが必要**です（README「反映」節の手順）。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc5bUGywmNrnFMvdrAciWc)_