### PR TITLE
feat(可視性): カテゴリ単位の閉鎖に対応（カテゴリページ410・導線からの除外）

### DIFF
--- a/src/lib/queries/quizVisibility.js
+++ b/src/lib/queries/quizVisibility.js
@@ -78,10 +78,35 @@ export const QUIZ_RETRACTED_LOOKUP = /* groq */ `*[
 
 export const QUIZ_ORDER_BY_PUBLISHED = `${QUIZ_PUBLISHED_FIELD} desc`;
 
-export const CATEGORY_DRAFT_FILTER = shouldRestrictToPublishedContent
-  ? `
+/**
+ * 閉鎖されていないカテゴリだけを通す条件（先頭に && を持たない素の式）。
+ * quiz と同じく「approved だけを通す」許可リスト方式。
+ */
+export const CATEGORY_NOT_RETRACTED_CONDITION = /* groq */ `coalesce(reviewStatus, "approved") == "approved"`;
+
+/**
+ * カテゴリ用フィルタ。閉鎖判定はプレビューの有無に関わらず常に適用する。
+ * これを通ることで、グローバルナビ・メニュー・sitemap・カテゴリ一覧から
+ * 閉鎖カテゴリが一括で消える。
+ */
+export const CATEGORY_DRAFT_FILTER =
+  (shouldRestrictToPublishedContent
+    ? `
   && !(_id in path("drafts.**"))`
-  : '';
+    : '') +
+  `
+  && ${CATEGORY_NOT_RETRACTED_CONDITION}`;
+
+/**
+ * スラッグから「存在するが閉鎖されている」カテゴリを引くクエリ。
+ * カテゴリページで 404 と 410 Gone を出し分けるために使う。
+ */
+export const CATEGORY_RETRACTED_LOOKUP = /* groq */ `*[
+  _type == "category"
+  && slug.current == $slug
+  && !(_id in path("drafts.**"))
+  && coalesce(reviewStatus, "approved") == "retracted"
+][0]{ _id, title, retractedReason }`;
 
 const toSlugString = (quiz) => {
   if (!quiz) return '';

--- a/src/lib/server/retracted.js
+++ b/src/lib/server/retracted.js
@@ -10,7 +10,7 @@
 
 import { error } from '@sveltejs/kit';
 import { client } from '$lib/sanity.server.js';
-import { QUIZ_RETRACTED_LOOKUP } from '$lib/queries/quizVisibility.js';
+import { CATEGORY_RETRACTED_LOOKUP, QUIZ_RETRACTED_LOOKUP } from '$lib/queries/quizVisibility.js';
 
 /**
  * 公開クエリが 0 件だったスラッグについて、非公開化されたものか単に存在しないのかを判定し、
@@ -33,4 +33,28 @@ export async function throwGoneOrNotFound(slug) {
   }
 
   throw error(404, `Quiz not found: ${slug}`);
+}
+
+/**
+ * 閉鎖されたカテゴリのページで 410 を返す。閉鎖されていなければ何もしない。
+ *
+ * カテゴリページはカテゴリ文書が取れなくても記事一覧だけで成立してしまう実装が
+ * あるため、「見つからなかったとき」ではなく**ページ表示の前に必ず**呼ぶ。
+ *
+ * @param {string} slug カテゴリスラッグ
+ * @returns {Promise<void>}
+ */
+export async function assertCategoryNotRetracted(slug) {
+  let retracted = null;
+  try {
+    retracted = await client.fetch(CATEGORY_RETRACTED_LOOKUP, { slug });
+  } catch (err) {
+    // 判定用クエリの失敗でページを壊さない。通常表示にフォールバックする。
+    console.error('[retracted] category lookup failed:', err);
+    return;
+  }
+
+  if (retracted?._id) {
+    throw error(410, 'このカテゴリは内容の見直しのため公開を終了しました。');
+  }
 }

--- a/src/routes/+layout.server.js
+++ b/src/routes/+layout.server.js
@@ -26,7 +26,6 @@ const FALLBACK_CATEGORIES = [
   { title: '計算クイズ', slug: 'arithmetic-quiz' },
   { title: 'クロスワード', slug: 'crossword' },
   { title: '数式パズル', slug: 'formula-puzzle' },
-  { title: 'ビジネスマナー', slug: 'business-manner' },
   { title: '数字クイズ', slug: 'number-quiz' }
 ];
 

--- a/src/routes/category/[slug]/+page.server.js
+++ b/src/routes/category/[slug]/+page.server.js
@@ -16,6 +16,7 @@ import {
   filterVisibleQuizzes
 } from '$lib/queries/quizVisibility.js';
 import { resolvePublishedDate } from '$lib/utils/publishedDate.js';
+import { assertCategoryNotRetracted } from '$lib/server/retracted.js';
 
 export const prerender = false;
 
@@ -202,6 +203,11 @@ const createFallbackResponse = (slug, path) => {
 export const load = async (event) => {
   const { params, setHeaders, url, isDataRequest } = event;
   const { slug } = params;
+
+  // 閉鎖されたカテゴリは 410 Gone。記事一覧だけで描画されてしまうのを防ぐため、
+  // 他の取得より先に判定する。
+  await assertCategoryNotRetracted(slug);
+
   const requestedPage = parsePageParam(url.searchParams.get('page'));
   const offset = (requestedPage - 1) * CATEGORY_PAGE_SIZE;
 

--- a/src/routes/category/business-manner/+page.server.js
+++ b/src/routes/category/business-manner/+page.server.js
@@ -16,6 +16,7 @@ import {
   filterVisibleQuizzes
 } from '$lib/queries/quizVisibility.js';
 import { resolvePublishedDate } from '$lib/utils/publishedDate.js';
+import { assertCategoryNotRetracted } from '$lib/server/retracted.js';
 
 export const prerender = false;
 
@@ -180,6 +181,11 @@ const createFallbackResponse = (slug, path) => {
 export const load = async (event) => {
   const { setHeaders, url, isDataRequest } = event;
   const slug = 'business-manner';
+
+  // 閉鎖されたカテゴリは 410 Gone。この静的ルートはカテゴリ文書が取れなくても
+  // 記事一覧だけで描画できてしまうため、他の取得より先に判定する。
+  await assertCategoryNotRetracted(slug);
+
   const requestedPage = parsePageParam(url.searchParams.get('page'));
   const offset = (requestedPage - 1) * CATEGORY_PAGE_SIZE;
 

--- a/studio/schemas/category.js
+++ b/studio/schemas/category.js
@@ -24,6 +24,34 @@ export default defineType({
       name: 'description',
       title: '説明',
       type: 'text'
+    }),
+
+    // ── 公開審査ステータス ─────────────────
+    // カテゴリ単位の閉鎖に使う。retracted にすると
+    // カテゴリページが 410 Gone を返し、グローバルナビ・メニュー・sitemap からも消える。
+    // ※ 所属記事は個別に quiz.reviewStatus を retracted にする必要がある
+    //   （retract-categories.py がカテゴリと記事をまとめて更新する）。
+    defineField({
+      name: 'reviewStatus',
+      title: '公開審査ステータス',
+      description:
+        '「閉鎖」にすると、カテゴリページが 410 Gone を返し、グローバルナビ・メニュー・sitemap から除外されます。カテゴリ文書は削除されないため、「公開可」へ戻せば復帰します。',
+      type: 'string',
+      options: {
+        list: [
+          {title: '✅ 公開可', value: 'approved'},
+          {title: '🚫 閉鎖（非公開）', value: 'retracted'}
+        ],
+        layout: 'radio'
+      },
+      initialValue: 'approved'
+    }),
+    defineField({
+      name: 'retractedReason',
+      title: '閉鎖の理由',
+      type: 'text',
+      rows: 2,
+      hidden: ({document}) => document?.reviewStatus !== 'retracted'
     })
   ],
   preview: {


### PR DESCRIPTION
## 目的

記事単位の非公開化（#573）に続き、**カテゴリ単位で閉鎖**できるようにします。トラフィックが僅少な8カテゴリ（481記事）を閉じるための土台です。

## 変更内容

### 1. `category` スキーマに `reviewStatus` を追加

`approved` / `retracted` の2状態。`quiz` と同じく「approved だけを通す」許可リスト方式です。閉鎖理由は `retractedReason` に記録します。

### 2. `CATEGORY_DRAFT_FILTER` に閉鎖判定を組み込み

このフィルタを使っている全経路へ一括で効きます。

- グローバルナビ（`+layout.server.js`）
- メニューのカテゴリ一覧
- sitemap のカテゴリURL
- `/category/[slug]` の一覧

### 3. 閉鎖カテゴリのページは 410 Gone

`/category/[slug]` と、静的ルートの `/category/business-manner` の両方に適用しました。

**判定を load の先頭に置いている**のが要点です。これらのページはカテゴリ文書が取得できなくても記事一覧だけで描画できてしまう実装なので、「カテゴリが見つからなかったとき」ではなく、他の取得より前に判定する必要がありました。

判定用クエリ自体が失敗した場合は通常表示にフォールバックし、ページを壊しません。

### 4. `FALLBACK_CATEGORIES` から `business-manner` を除去

Sanity の取得に失敗したときのフォールバックにハードコードされており、このままだと閉鎖後もメニューに出続けるためです。

なお `ArticleCard.svelte` のカテゴリ色定義と `quiz-stub.js`（テスト用スタブ）にも閉鎖対象の名前が残っていますが、前者は単なる色のルックアップ、後者は `ENABLE_QUIZ_STUB` 時のみ使われるダミーデータのため、実害はなく手を入れていません。

## 動作への影響

`reviewStatus` 未設定のカテゴリは `approved` 扱いのため、**このマージ時点で消えるカテゴリはありません**。実際の閉鎖は automations 側の `Retract Categories` ワークフローで行います。

## 検証

`SKIP_SANITY=1 pnpm build` 成功。

変更した5ファイルのうち4ファイルは prettier 警告が出ますが、**いずれも変更前から警告状態**でした（無関係な差分を増やさないため触っていません）。私の編集で崩れた `src/lib/server/retracted.js` のみ整形済みです。

## 関連

- automations 側: NBWMedia0807/noutore-biyori-automations#92

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xc5bUGywmNrnFMvdrAciWc)_